### PR TITLE
refactor(ui): unify ApkToolBoxGUI UI with shared UiKit (screenshot-verified)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target/
 
 tmp/
 .kiro/
+ui-shots/

--- a/src/main/java/edu/jiangxin/apktoolbox/android/dumpsys/DumpsysPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/android/dumpsys/DumpsysPanel.java
@@ -3,6 +3,7 @@ package edu.jiangxin.apktoolbox.android.dumpsys;
 import edu.jiangxin.apktoolbox.android.dumpsys.tojson.IDumpsys2Json;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.filepanel.FilePanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -52,10 +53,11 @@ public class DumpsysPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        setPreferredSize(new Dimension(700, 400));
+        setPreferredSize(new Dimension(760, 420));
+        setLayout(new BorderLayout());
 
         JTabbedPane tabbedPane = new JTabbedPane();
-        add(tabbedPane);
+        add(tabbedPane, BorderLayout.CENTER);
 
         createDumpsysPanel();
         tabbedPane.addTab("Dumpsys", null, dumpsysPanel, "Dumpsys");
@@ -73,17 +75,16 @@ public class DumpsysPanel extends EasyPanel {
 
     private void createDumpsysPanel() {
         dumpsysPanel = new JPanel();
-        BoxLayout layout = new BoxLayout(dumpsysPanel, BoxLayout.Y_AXIS);
-        dumpsysPanel.setLayout(layout);
-        dumpsysPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        dumpsysPanel.setLayout(new BoxLayout(dumpsysPanel, BoxLayout.Y_AXIS));
+        dumpsysPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createDumpsysTargetDirPanel();
-        dumpsysPanel.add(dumpsysTargetDirPanel);
-        dumpsysPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        dumpsysPanel.add(UiKit.formRow("Save Directory", dumpsysTargetDirPanel));
+        dumpsysPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createDumpsysOptionPanel();
         dumpsysPanel.add(dumpsysOptionPanel);
-        dumpsysPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        dumpsysPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createDumpsysOperationPanel();
         dumpsysPanel.add(dumpsysOperationPanel);
@@ -91,17 +92,16 @@ public class DumpsysPanel extends EasyPanel {
 
     private void createAnalysisPanel() {
         analysisPanel = new JPanel();
-        BoxLayout layout = new BoxLayout(analysisPanel, BoxLayout.Y_AXIS);
-        analysisPanel.setLayout(layout);
-        dumpsysPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        analysisPanel.setLayout(new BoxLayout(analysisPanel, BoxLayout.Y_AXIS));
+        analysisPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createAnalysisTargetFilePanel();
-        analysisPanel.add(analysisFilePanel);
-        analysisPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        analysisPanel.add(UiKit.formRow("Source File", analysisFilePanel));
+        analysisPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createAnalysisOutputPanel();
         analysisPanel.add(analysisOutputScrollPane);
-        analysisPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        analysisPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createAnalysisOperationPanel();
         analysisPanel.add(analysisOperationPanel);
@@ -124,14 +124,10 @@ public class DumpsysPanel extends EasyPanel {
     }
 
     private void createAnalysisOperationPanel() {
-        analysisOperationPanel = new JPanel();
-        BoxLayout boxLayout = new BoxLayout(analysisOperationPanel, BoxLayout.X_AXIS);
-        analysisOperationPanel.setLayout(boxLayout);
-
-        JButton analysisStartButton = new JButton("Start");
+        JButton analysisStartButton = UiKit.primaryButton("Start");
         analysisStartButton.setEnabled(true);
         analysisStartButton.addActionListener(new AnalysisStartButtonActionListener());
-        analysisOperationPanel.add(analysisStartButton);
+        analysisOperationPanel = UiKit.actionRow(analysisStartButton);
     }
 
     private void createDumpsysTargetDirPanel() {

--- a/src/main/java/edu/jiangxin/apktoolbox/android/dumpsys/DumpsysPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/android/dumpsys/DumpsysPanel.java
@@ -16,6 +16,7 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rtextarea.RTextScrollPane;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -90,6 +91,54 @@ public class DumpsysPanel extends EasyPanel {
         dumpsysPanel.add(dumpsysOperationPanel);
     }
 
+    private void createDumpsysOptionPanel() {
+        dumpsysOptionPanel = new JPanel();
+        dumpsysOptionPanel.setLayout(new BoxLayout(dumpsysOptionPanel, BoxLayout.Y_AXIS));
+        dumpsysOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        dumpsysOptionPanel.setBorder(UiKit.sectionBorder("Dumpsys Types"));
+
+        JCheckBox allSelectedCheckBox = new JCheckBox("Select All");
+        allSelectedCheckBox.setSelected(false);
+        allSelectedCheckBox.addActionListener(e -> {
+            boolean selected = allSelectedCheckBox.isSelected();
+            for (Component component : dumpsysTypeChoosePanel.getComponents()) {
+                if (component instanceof JCheckBox checkBox) {
+                    checkBox.setSelected(selected);
+                    checkBox.setEnabled(!selected);
+                }
+            }
+        });
+
+        dumpsysTypeChoosePanel = new JPanel();
+        dumpsysTypeChoosePanel.setLayout(new GridLayout(0, 4, UiKit.GAP_SM, UiKit.GAP_SM));
+        dumpsysTypeChoosePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        dumpsysTypeChoosePanel.setBorder(new EmptyBorder(UiKit.GAP_XS, 0, 0, 0));
+
+        String[] types = {
+                "input", "window", "SurfaceFlinger", "activity",
+                "accessibility", "package", "alarm", "input_method",
+                "sensorservice", "account", "display", "power", "battery"
+        };
+        for (String type : types) {
+            JCheckBox checkBox = new JCheckBox(type);
+            if ("input".equals(type)) {
+                checkBox.setSelected(true);
+            }
+            dumpsysTypeChoosePanel.add(checkBox);
+        }
+
+        dumpsysOptionPanel.add(UiKit.checkRow(allSelectedCheckBox));
+        dumpsysOptionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        dumpsysOptionPanel.add(dumpsysTypeChoosePanel);
+    }
+
+    private void createDumpsysOperationPanel() {
+        dumpsysStartButton = UiKit.primaryButton("Start");
+        dumpsysStartButton.setEnabled(true);
+        dumpsysStartButton.addActionListener(new DumpsysStartButtonActionListener());
+        dumpsysOperationPanel = UiKit.actionRow(dumpsysStartButton);
+    }
+
     private void createAnalysisPanel() {
         analysisPanel = new JPanel();
         analysisPanel.setLayout(new BoxLayout(analysisPanel, BoxLayout.Y_AXIS));
@@ -131,90 +180,9 @@ public class DumpsysPanel extends EasyPanel {
     }
 
     private void createDumpsysTargetDirPanel() {
-        dumpsysTargetDirPanel = new FilePanel("Target Directory");
+        dumpsysTargetDirPanel = new FilePanel("Browse...");
         dumpsysTargetDirPanel.initialize();
         dumpsysTargetDirPanel.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-    }
-
-    private void createDumpsysOptionPanel() {
-        dumpsysOptionPanel = new JPanel();
-        BoxLayout boxLayout = new BoxLayout(dumpsysOptionPanel, BoxLayout.Y_AXIS);
-        dumpsysOptionPanel.setLayout(boxLayout);
-
-        JPanel dumpsysCheckboxPanel = new JPanel();
-        dumpsysCheckboxPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 10, 3));
-
-        JCheckBox allSelectedCheckBox = new JCheckBox("Select All");
-        allSelectedCheckBox.setSelected(false);
-        allSelectedCheckBox.addActionListener(e -> {
-            boolean selected = allSelectedCheckBox.isSelected();
-            if (selected) {
-                Component[] components = dumpsysTypeChoosePanel.getComponents();
-                for (Component component : components) {
-                    if (component instanceof JCheckBox checkBox) {
-                        checkBox.setSelected(true);
-                        checkBox.setEnabled(false);
-                    }
-                }
-            } else {
-                Component[] components = dumpsysTypeChoosePanel.getComponents();
-                for (Component component : components) {
-                    if (component instanceof JCheckBox checkBox) {
-                        checkBox.setSelected(false);
-                        checkBox.setEnabled(true);
-                    }
-                }
-            }
-
-        });
-        dumpsysCheckboxPanel.add(allSelectedCheckBox);
-
-        dumpsysTypeChoosePanel = new JPanel();
-        dumpsysTypeChoosePanel.setLayout(new FlowLayout(FlowLayout.LEFT, 10, 3));
-        dumpsysTypeChoosePanel.setPreferredSize(new Dimension(500, 200));
-
-        JCheckBox inputCheckBox = new JCheckBox("input");
-        inputCheckBox.setSelected(true);
-        JCheckBox windowCheckBox = new JCheckBox("window");
-        dumpsysTypeChoosePanel.add(windowCheckBox);
-        JCheckBox SurfaceFlingerCheckBox = new JCheckBox("SurfaceFlinger");
-        dumpsysTypeChoosePanel.add(SurfaceFlingerCheckBox);
-        JCheckBox activityCheckBox = new JCheckBox("activity");
-        dumpsysTypeChoosePanel.add(activityCheckBox);
-        JCheckBox accessibilityCheckBox = new JCheckBox("accessibility");
-        dumpsysTypeChoosePanel.add(accessibilityCheckBox);
-        JCheckBox packageCheckBox = new JCheckBox("package");
-        dumpsysTypeChoosePanel.add(packageCheckBox);
-        JCheckBox alarmCheckBox = new JCheckBox("alarm");
-        dumpsysTypeChoosePanel.add(alarmCheckBox);
-        JCheckBox inputMethodCheckBox = new JCheckBox("input_method");
-        dumpsysTypeChoosePanel.add(inputMethodCheckBox);
-        JCheckBox sensorServiceCheckBox = new JCheckBox("sensorservice");
-        dumpsysTypeChoosePanel.add(sensorServiceCheckBox);
-        JCheckBox accountCheckBox = new JCheckBox("account");
-        dumpsysTypeChoosePanel.add(accountCheckBox);
-        JCheckBox displayCheckBox = new JCheckBox("display");
-        dumpsysTypeChoosePanel.add(displayCheckBox);
-        JCheckBox powerCheckBox = new JCheckBox("power");
-        dumpsysTypeChoosePanel.add(powerCheckBox);
-        JCheckBox batteryCheckBox = new JCheckBox("battery");
-        dumpsysTypeChoosePanel.add(batteryCheckBox);
-
-        dumpsysOptionPanel.add(dumpsysCheckboxPanel);
-        dumpsysOptionPanel.add(new JSeparator(JSeparator.HORIZONTAL));
-        dumpsysOptionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        dumpsysOptionPanel.add(dumpsysTypeChoosePanel);
-    }
-
-    private void createDumpsysOperationPanel() {
-        dumpsysOperationPanel = new JPanel();
-        BoxLayout boxLayout = new BoxLayout(dumpsysOperationPanel, BoxLayout.X_AXIS);
-        dumpsysOperationPanel.setLayout(boxLayout);
-
-        dumpsysStartButton = new JButton("Start");
-        dumpsysStartButton.setEnabled(true);
-        dumpsysStartButton.addActionListener(new DumpsysStartButtonActionListener());
-        dumpsysOperationPanel.add(dumpsysStartButton);
     }
 
     class DumpsysStartButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/android/i18n/I18nAddPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/android/i18n/I18nAddPanel.java
@@ -5,7 +5,7 @@ package edu.jiangxin.apktoolbox.android.i18n;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.listener.SelectDirectoryListener;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.SAXBuilderHelper;
 import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.io.FileUtils;
@@ -61,24 +61,21 @@ public class I18nAddPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Internationalization Resources"));
 
         createSourcePanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createTargetPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createItemPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createOperationPanel();
     }
 
     private void createOperationPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        add(operationPanel);
-
-        JButton addButton = new JButton(bundle.getString("android.i18n.add.title"));
+        JButton addButton = UiKit.primaryButton(bundle.getString("android.i18n.add.title"));
         addButton.addActionListener(e -> {
             String srcPath = checkAndGetDirContent(srcTextField, "android.i18n.add.src.dir", "Source directory is invalid");
             if (srcPath == null) {
@@ -111,54 +108,33 @@ public class I18nAddPanel extends EasyPanel {
             JOptionPane.showMessageDialog(this, message, "INFO", JOptionPane.INFORMATION_MESSAGE);
         });
 
-        operationPanel.add(addButton);
+        add(UiKit.actionRow(addButton));
     }
 
     private void createItemPanel() {
-        JPanel itemPanel = new JPanel();
-        itemPanel.setLayout(new BoxLayout(itemPanel, BoxLayout.X_AXIS));
-        add(itemPanel);
-        
-        itemTextField = new JTextField();
+        itemTextField = UiKit.field(new JTextField());
         itemTextField.setText(conf.getString("android.i18n.add.items"));
-
-        JLabel itemLabel = new JLabel("Items");
-
-        itemPanel.add(itemTextField);
-        itemPanel.add(Box.createHorizontalGlue());
-        itemPanel.add(itemLabel);
+        add(UiKit.formRow("Items", itemTextField));
     }
 
     private void createTargetPanel() {
-        JPanel targetPanel = new JPanel();
-        targetPanel.setLayout(new BoxLayout(targetPanel, BoxLayout.X_AXIS));
-        add(targetPanel);
-        
-        targetTextField = new JTextField();
+        targetTextField = UiKit.field(new JTextField());
         targetTextField.setText(conf.getString("android.i18n.add.target.dir"));
 
-        JButton targetButton = new JButton("Save Directory");
+        JButton targetButton = UiKit.secondaryButton("Browse...");
         targetButton.addActionListener(new SelectDirectoryListener("save to", targetTextField));
 
-        targetPanel.add(targetTextField);
-        targetPanel.add(Box.createHorizontalGlue());
-        targetPanel.add(targetButton);
+        add(UiKit.formRow("Target Directory", targetTextField, targetButton));
     }
 
     private void createSourcePanel() {
-        JPanel sourcePanel = new JPanel();
-        sourcePanel.setLayout(new BoxLayout(sourcePanel, BoxLayout.X_AXIS));
-        add(sourcePanel);
-        
-        srcTextField = new JTextField();
+        srcTextField = UiKit.field(new JTextField());
         srcTextField.setText(conf.getString("android.i18n.add.src.dir"));
 
-        JButton srcButton = new JButton("Source Directory");
+        JButton srcButton = UiKit.secondaryButton("Browse...");
         srcButton.addActionListener(new SelectDirectoryListener("select a directory", srcTextField));
 
-        sourcePanel.add(srcTextField);
-        sourcePanel.add(Box.createHorizontalGlue());
-        sourcePanel.add(srcButton);
+        add(UiKit.formRow("Source Directory", srcTextField, srcButton));
     }
 
     private int innerProcessor(String sourceBaseStr, String targetBaseStr, String itemName) {

--- a/src/main/java/edu/jiangxin/apktoolbox/android/i18n/I18nFindLongestPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/android/i18n/I18nFindLongestPanel.java
@@ -2,7 +2,7 @@ package edu.jiangxin.apktoolbox.android.i18n;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.listener.SelectDirectoryListener;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.SAXBuilderHelper;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -43,22 +43,19 @@ public class I18nFindLongestPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Internationalization Resources"));
 
         createSourcePanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createItemPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createOperationPanel();
     }
 
     private void createOperationPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        add(operationPanel);
-
-        JButton findButton = new JButton(bundle.getString("android.i18n.longest.find"));
+        JButton findButton = UiKit.primaryButton(bundle.getString("android.i18n.longest.find"));
         findButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -93,38 +90,23 @@ public class I18nFindLongestPanel extends EasyPanel {
             }
         });
 
-        operationPanel.add(findButton);
+        add(UiKit.actionRow(findButton));
     }
 
     private void createItemPanel() {
-        JPanel itemPanel = new JPanel();
-        itemPanel.setLayout(new BoxLayout(itemPanel, BoxLayout.X_AXIS));
-        add(itemPanel);
-        
-        itemTextField = new JTextField();
+        itemTextField = UiKit.field(new JTextField());
         itemTextField.setText(conf.getString("android.i18n.longest.items"));
-
-        JLabel itemLabel = new JLabel("Items");
-
-        itemPanel.add(itemTextField);
-        itemPanel.add(Box.createHorizontalGlue());
-        itemPanel.add(itemLabel);
+        add(UiKit.formRow("Items", itemTextField));
     }
 
     private void createSourcePanel() {
-        JPanel sourcePanel = new JPanel();
-        sourcePanel.setLayout(new BoxLayout(sourcePanel, BoxLayout.X_AXIS));
-        add(sourcePanel);
-        
-        srcTextField = new JTextField();
+        srcTextField = UiKit.field(new JTextField());
         srcTextField.setText(conf.getString("android.i18n.longest.src.dir"));
 
-        JButton srcButton = new JButton("Source Directory");
+        JButton srcButton = UiKit.secondaryButton("Browse...");
         srcButton.addActionListener(new SelectDirectoryListener("select a directory", srcTextField));
 
-        sourcePanel.add(srcTextField);
-        sourcePanel.add(Box.createHorizontalGlue());
-        sourcePanel.add(srcButton);
+        add(UiKit.formRow("Source Directory", srcTextField, srcButton));
     }
 
     private String getCanonicalPath(File file) {

--- a/src/main/java/edu/jiangxin/apktoolbox/android/i18n/I18nRemovePanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/android/i18n/I18nRemovePanel.java
@@ -24,7 +24,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
+import java.awt.Component;
 
 /**
  * @author jiangxin
@@ -49,22 +50,19 @@ public class I18nRemovePanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Internationalization Resources"));
 
         createSourcePanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createItemPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createOperationPanel();
     }
 
     private void createOperationPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        add(operationPanel);
-
-        JButton removeButton = new JButton(bundle.getString("android.i18n.remove.title"));
+        JButton removeButton = UiKit.primaryButton(bundle.getString("android.i18n.remove.title"));
         removeButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -84,38 +82,23 @@ public class I18nRemovePanel extends EasyPanel {
             }
         });
 
-        operationPanel.add(removeButton);
+        add(UiKit.actionRow(removeButton));
     }
 
     private void createItemPanel() {
-        JPanel itemPanel = new JPanel();
-        itemPanel.setLayout(new BoxLayout(itemPanel, BoxLayout.X_AXIS));
-        add(itemPanel);
-        
-        itemTextField = new JTextField();
+        itemTextField = UiKit.field(new JTextField());
         itemTextField.setText(conf.getString("android.i18n.remove.items"));
-
-        JLabel itemLabel = new JLabel("Items");
-
-        itemPanel.add(itemTextField);
-        itemPanel.add(Box.createHorizontalGlue());
-        itemPanel.add(itemLabel);
+        add(UiKit.formRow("Items", itemTextField));
     }
 
     private void createSourcePanel() {
-        JPanel sourcePanel = new JPanel();
-        sourcePanel.setLayout(new BoxLayout(sourcePanel, BoxLayout.X_AXIS));
-        add(sourcePanel);
-        
-        srcTextField = new JTextField();
+        srcTextField = UiKit.field(new JTextField());
         srcTextField.setText(conf.getString("android.i18n.remove.src.dir"));
 
-        JButton srcButton = new JButton("Source Directory");
+        JButton srcButton = UiKit.secondaryButton("Browse...");
         srcButton.addActionListener(new SelectDirectoryListener("select a directory", srcTextField));
 
-        sourcePanel.add(srcTextField);
-        sourcePanel.add(Box.createHorizontalGlue());
-        sourcePanel.add(srcButton);
+        add(UiKit.formRow("Source Directory", srcTextField, srcButton));
     }
 
     private void remove(String sourceBaseStr, String itemName) {

--- a/src/main/java/edu/jiangxin/apktoolbox/android/screenshot/ScreenShotPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/android/screenshot/ScreenShotPanel.java
@@ -1,7 +1,7 @@
 package edu.jiangxin.apktoolbox.android.screenshot;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.DateUtils;
 import edu.jiangxin.apktoolbox.utils.Utils;
 import org.apache.commons.lang3.StringUtils;
@@ -39,72 +39,58 @@ public class ScreenShotPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Screenshot"));
 
         createDirectoryPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createFileNamePanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
         createScreenshotPanel();
     }
 
     private void createScreenshotPanel() {
-        JPanel screenshotPanel = new JPanel();
-        screenshotPanel.setLayout(new BoxLayout(screenshotPanel, BoxLayout.X_AXIS));
-        add(screenshotPanel);
-
-        openCheckBox = new JCheckBox("Open Dir");
+        openCheckBox = new JCheckBox("Open Directory");
         openCheckBox.setSelected(false);
 
-        copyCheckBox = new JCheckBox("Copy Pic");
+        copyCheckBox = new JCheckBox("Copy to Clipboard");
         copyCheckBox.setSelected(false);
 
-        JButton screenshotButton = new JButton("Sceenshot");
+        JButton screenshotButton = UiKit.primaryButton("Screenshot");
         screenshotButton.addActionListener(new ScreenshotButtonActionListener());
 
-        JButton getExistButton = new JButton("Get Exist");
+        JButton getExistButton = UiKit.secondaryButton("Get Existing");
         getExistButton.addActionListener(new GetExistButtonActionListener());
 
-        screenshotPanel.add(openCheckBox);
-        screenshotPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        screenshotPanel.add(copyCheckBox);
-        screenshotPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        screenshotPanel.add(screenshotButton);
-        screenshotPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        screenshotPanel.add(getExistButton);
+        add(UiKit.checkRow(openCheckBox, copyCheckBox));
+        add(Box.createVerticalStrut(UiKit.GAP_SM));
+        add(UiKit.actionRow(getExistButton, screenshotButton));
     }
 
     private void createFileNamePanel() {
-        JPanel fileNamePanel = new JPanel();
-        fileNamePanel.setLayout(new BoxLayout(fileNamePanel, BoxLayout.X_AXIS));
-        add(fileNamePanel);
-
-        fileNameTextField = new JTextField();
+        fileNameTextField = UiKit.field(new JTextField());
         fileNameTextField.setToolTipText("timestamp default(for example: 20180101122345.png)");
 
-        JButton fileNameButton = new JButton("File name");
+        JButton fileNameButton = UiKit.secondaryButton("File Name");
+        fileNameButton.addActionListener(e -> fileNameTextField.requestFocusInWindow());
 
-        fileNamePanel.add(fileNameTextField);
-        fileNamePanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        fileNamePanel.add(fileNameButton);
+        JPanel fileNamePanel = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        fileNamePanel.setOpaque(false);
+        fileNamePanel.add(UiKit.formRow("File Name", fileNameTextField), BorderLayout.CENTER);
+        fileNamePanel.add(fileNameButton, BorderLayout.EAST);
+        add(fileNamePanel);
     }
 
     private void createDirectoryPanel() {
-        JPanel directoryPanel = new JPanel();
-        directoryPanel.setLayout(new BoxLayout(directoryPanel, BoxLayout.X_AXIS));
-        add(directoryPanel);
-
-        directoryTextField = new JTextField();
+        directoryTextField = UiKit.field(new JTextField());
         directoryTextField.setText(conf.getString("screenshot.save.dir", System.getenv("USERPROFILE")));
         directoryTextField.setTransferHandler(new DirectoryTextFieldTransferHandler());
 
-        JButton directoryButton = new JButton("Save Directory");
+        JButton directoryButton = UiKit.secondaryButton("Browse...");
         directoryButton.addActionListener(new DirectoryButtonActionListener());
 
-        directoryPanel.add(directoryTextField);
-        directoryPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        directoryPanel.add(directoryButton);
+        add(UiKit.formRow("Save Directory", directoryTextField, directoryButton));
     }
 
     private final class DirectoryButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/EncodeConvertPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/EncodeConvertPanel.java
@@ -5,7 +5,7 @@ import edu.jiangxin.apktoolbox.file.core.EncoderDetector;
 import edu.jiangxin.apktoolbox.swing.extend.autocomplete.AutoCompleteComboBox;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -51,14 +51,15 @@ public class EncodeConvertPanel extends EasyPanel {
     @Override
     public void initUI() {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createSrcPanel();
         add(srcPanel);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOptionPanel();
         add(optionPanel);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
         add(operationPanel);
@@ -71,61 +72,47 @@ public class EncodeConvertPanel extends EasyPanel {
 
     private void createOptionPanel() {
         optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Options"));
 
-        JLabel suffixLabel = new JLabel("Suffix:");
-        optionPanel.add(suffixLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-
-        suffixTextField = new JTextField();
+        suffixTextField = UiKit.field(new JTextField());
         suffixTextField.setToolTipText("an array of extensions, ex. {\"java\",\"xml\"}. If this parameter is empty, all files are returned.");
         suffixTextField.setText(conf.getString("encodeconvert.suffix"));
-        optionPanel.add(suffixTextField);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
         recursiveCheckBox = new JCheckBox("Recursive");
         recursiveCheckBox.setSelected(true);
-        optionPanel.add(recursiveCheckBox);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
-        JLabel fromLabel = new JLabel("From:");
-        optionPanel.add(fromLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-
-        fromComboBox = new AutoCompleteComboBox<String>();
+        fromComboBox = new AutoCompleteComboBox<>();
         fromComboBox.initialize();
         fromComboBox.setEnabled(false);
-        optionPanel.add(fromComboBox);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
         autoDetectCheckBox = new JCheckBox("Auto Detect");
         autoDetectCheckBox.setSelected(true);
         autoDetectCheckBox.addItemListener(e -> fromComboBox.setEnabled(!(e.getStateChange() == ItemEvent.SELECTED)));
-        optionPanel.add(autoDetectCheckBox);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
-        JLabel toLabel = new JLabel("To:");
-        optionPanel.add(toLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-
-        toComboBox = new AutoCompleteComboBox<String>();
+        toComboBox = new AutoCompleteComboBox<>();
         toComboBox.initialize();
         toComboBox.setSelectedItem(conf.getString("encodeconvert.to"));
-        optionPanel.add(toComboBox);
 
         for (String charset : Charset.availableCharsets().keySet()) {
             fromComboBox.addItem(charset);
             toComboBox.addItem(charset);
         }
+
+        optionPanel.add(UiKit.formRow("Suffix", suffixTextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.checkRow(recursiveCheckBox, autoDetectCheckBox));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.formRow("From", fromComboBox));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.formRow("To", toComboBox));
     }
 
     private void createOperationPanel() {
-        operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        JButton convertButton = new JButton("Convert");
+        JButton convertButton = UiKit.primaryButton("Convert");
         convertButton.addActionListener(new ConvertButtonActionListener());
-
-        operationPanel.add(convertButton);
+        operationPanel = UiKit.actionRow(convertButton);
     }
 
     private class ConvertButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/OsConvertPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/OsConvertPanel.java
@@ -3,7 +3,7 @@ package edu.jiangxin.apktoolbox.file;
 import edu.jiangxin.apktoolbox.file.core.OsPatternConvert;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,58 +43,52 @@ public class OsConvertPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createSrcPanel();
         add(srcPanel);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOptionPanel();
         add(optionPanel);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
         add(operationPanel);
     }
 
     private void createOperationPanel() {
-        operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-
-        JButton convertButton = new JButton("Convert");
+        JButton convertButton = UiKit.primaryButton("Convert");
         convertButton.addActionListener(new ConvertButtonActionListener());
-
-        operationPanel.add(convertButton);
+        operationPanel = UiKit.actionRow(convertButton);
     }
 
     private void createOptionPanel() {
         optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Options"));
 
-        JLabel suffixLabel = new JLabel("Suffix:");
-        suffixTextField = new JTextField();
+        suffixTextField = UiKit.field(new JTextField());
         suffixTextField.setToolTipText("an array of extensions, ex. {\"java\",\"xml\"}. If this parameter is empty, all files are returned.");
         suffixTextField.setText(conf.getString("osconvert.suffix"));
-        optionPanel.add(suffixLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        optionPanel.add(suffixTextField);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
         recursiveCheckBox = new JCheckBox("Recursive");
         recursiveCheckBox.setSelected(true);
-        optionPanel.add(recursiveCheckBox);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
-        JLabel typeLabel = new JLabel("Type:");
         typeComboBox = new JComboBox<>();
         typeComboBox.addItem("Convert to UNIX(LF Only)");
         typeComboBox.addItem("Convert to Macintosh(CR Only)");
         typeComboBox.addItem("Convert to Windows(CR+LF)");
+        typeComboBox.setPreferredSize(new Dimension(260, UiKit.FIELD_HEIGHT));
+        typeComboBox.setMaximumSize(new Dimension(260, UiKit.FIELD_HEIGHT));
 
-        optionPanel.add(typeLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        optionPanel.add(typeComboBox);
+        optionPanel.add(UiKit.formRow("Suffix", suffixTextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.checkRow(recursiveCheckBox));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.formRow("Type", typeComboBox));
     }
 
     private void createSrcPanel() {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/batchrename/BatchRenamePanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/batchrename/BatchRenamePanel.java
@@ -322,14 +322,9 @@ public class BatchRenamePanel extends EasyPanel {
         operationPanel.setBorder(UiKit.sectionBorder("6. 操作"));
         operationPanel.setLayout(new BorderLayout());
 
-        JPanel secondLevelPanel = new JPanel();
-        secondLevelPanel.setLayout(new BoxLayout(secondLevelPanel, BoxLayout.X_AXIS));
-        operationPanel.add(secondLevelPanel);
-
         JButton button = UiKit.primaryButton("Start");
         button.addActionListener(new StartButtonActionListener());
-        secondLevelPanel.add(Box.createHorizontalGlue());
-        secondLevelPanel.add(button);
+        operationPanel.add(UiKit.actionRow(button), BorderLayout.CENTER);
     }
 
     private void createStatusPanel() {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/batchrename/BatchRenamePanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/batchrename/BatchRenamePanel.java
@@ -2,6 +2,7 @@ package edu.jiangxin.apktoolbox.file.batchrename;
 
 import edu.jiangxin.apktoolbox.swing.extend.listener.SelectDirectoryListener;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -101,13 +102,18 @@ public class BatchRenamePanel extends EasyPanel {
     private void createWarningPanel() {
         warningPanel = new JPanel();
         warningPanel.setLayout(new BoxLayout(warningPanel, BoxLayout.X_AXIS));
+        warningPanel.setBorder(UiKit.sectionBorder("Warning"));
 
         JTextArea warningTextArea = new JTextArea();
-        warningTextArea.setText("It is dangerous to operate on the original files! \nPlease back up at first and check the result carefully at end!");
-        warningTextArea.setForeground(Color.RED);
-        warningTextArea.setFont(new Font("宋体", Font.BOLD, 20));
+        warningTextArea.setText("It is dangerous to operate on the original files!\nPlease back up first and check the result carefully at the end!");
+        warningTextArea.setForeground(UiKit.DANGER);
+        warningTextArea.setFont(getFont().deriveFont(Font.BOLD, 14f));
+        warningTextArea.setOpaque(false);
         warningTextArea.setBorder(null);
         warningTextArea.setEditable(false);
+        warningTextArea.setLineWrap(true);
+        warningTextArea.setWrapStyleWord(true);
+        warningTextArea.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         warningPanel.add(warningTextArea);
         warningPanel.add(Box.createHorizontalGlue());
@@ -313,17 +319,17 @@ public class BatchRenamePanel extends EasyPanel {
 
     private void createOperationPanel() {
         operationPanel = new JPanel();
-        operationPanel.setBorder(BorderFactory.createTitledBorder("6. 操作"));
+        operationPanel.setBorder(UiKit.sectionBorder("6. 操作"));
         operationPanel.setLayout(new BorderLayout());
 
         JPanel secondLevelPanel = new JPanel();
         secondLevelPanel.setLayout(new BoxLayout(secondLevelPanel, BoxLayout.X_AXIS));
         operationPanel.add(secondLevelPanel);
 
-        JButton button = new JButton("开始");
+        JButton button = UiKit.primaryButton("Start");
         button.addActionListener(new StartButtonActionListener());
-        secondLevelPanel.add(button);
         secondLevelPanel.add(Box.createHorizontalGlue());
+        secondLevelPanel.add(button);
     }
 
     private void createStatusPanel() {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/checksum/panel/FileChecksumPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/checksum/panel/FileChecksumPanel.java
@@ -3,11 +3,12 @@ package edu.jiangxin.apktoolbox.file.checksum.panel;
 import edu.jiangxin.apktoolbox.file.checksum.CalculateType;
 import edu.jiangxin.apktoolbox.swing.extend.EasyChildTabbedPanel;
 import edu.jiangxin.apktoolbox.swing.extend.filepanel.FilePanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 
 import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -40,18 +41,17 @@ public class FileChecksumPanel extends EasyChildTabbedPanel {
 
     @Override
     public void createUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
         createFileNamePanel();
-        add(filePanel);
+        add(UiKit.formRow("File", filePanel));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
         createOptionPanel();
         add(optionPanel);
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
         createOperationPanel();
         add(operationPanel);
     }
@@ -70,98 +70,60 @@ public class FileChecksumPanel extends EasyChildTabbedPanel {
 
     private void createOptionPanel() {
         optionPanel = new JPanel();
-        BoxLayout boxLayout = new BoxLayout(optionPanel, BoxLayout.Y_AXIS);
-        optionPanel.setLayout(boxLayout);
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Checksums"));
 
-        JPanel sizeOptionPanel = new JPanel();
-        JPanel lastModifiedTimeOptionPanel = new JPanel();
-        JPanel md5OptionPanel = new JPanel();
-        JPanel sha1OptionPanel = new JPanel();
-        JPanel sha256OptionPanel = new JPanel();
-        JPanel sha384OptionPanel = new JPanel();
-        JPanel sha512OptionPanel = new JPanel();
-        JPanel crc32OptionPanel = new JPanel();
+        sizeTextField = UiKit.field(new JTextField());
+        sizeTextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("Size", sizeTextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        optionPanel.add(sizeOptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(lastModifiedTimeOptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(md5OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha1OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha256OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha384OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha512OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(crc32OptionPanel);
+        lastModifiedTimeTextField = UiKit.field(new JTextField());
+        lastModifiedTimeTextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("Last Modified", lastModifiedTimeTextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sizeOptionPanel.setLayout(new BoxLayout(sizeOptionPanel, BoxLayout.X_AXIS));
-        JLabel fileSizeLabel = new JLabel("Size:");
-        sizeTextField = new JTextField();
-        sizeOptionPanel.add(fileSizeLabel);
-        sizeOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sizeOptionPanel.add(sizeTextField);
-
-        lastModifiedTimeOptionPanel.setLayout(new BoxLayout(lastModifiedTimeOptionPanel, BoxLayout.X_AXIS));
-        JLabel fileLastModifiedTimeLabel = new JLabel("Last Modified Time:");
-        lastModifiedTimeTextField = new JTextField();
-        lastModifiedTimeOptionPanel.add(fileLastModifiedTimeLabel);
-        lastModifiedTimeOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        lastModifiedTimeOptionPanel.add(lastModifiedTimeTextField);
-
-        md5OptionPanel.setLayout(new BoxLayout(md5OptionPanel, BoxLayout.X_AXIS));
-        md5CheckBox = new JCheckBox("MD5 checksum:");
+        md5CheckBox = new JCheckBox("MD5");
         md5CheckBox.setSelected(true);
-        md5TextField = new JTextField();
-        md5OptionPanel.add(md5CheckBox);
-        md5OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        md5OptionPanel.add(md5TextField);
+        md5TextField = UiKit.field(new JTextField());
+        md5TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("MD5", md5CheckBox, md5TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha1OptionPanel.setLayout(new BoxLayout(sha1OptionPanel, BoxLayout.X_AXIS));
-        sha1CheckBox = new JCheckBox("SHA1 checksum:");
-        sha1TextField = new JTextField();
-        sha1OptionPanel.add(sha1CheckBox);
-        sha1OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha1OptionPanel.add(sha1TextField);
+        sha1CheckBox = new JCheckBox("SHA1");
+        sha1TextField = UiKit.field(new JTextField());
+        sha1TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA1", sha1CheckBox, sha1TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha256OptionPanel.setLayout(new BoxLayout(sha256OptionPanel, BoxLayout.X_AXIS));
-        sha256CheckBox = new JCheckBox("SHA256 checksum:");
-        sha256TextField = new JTextField();
-        sha256OptionPanel.add(sha256CheckBox);
-        sha256OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha256OptionPanel.add(sha256TextField);
+        sha256CheckBox = new JCheckBox("SHA256");
+        sha256TextField = UiKit.field(new JTextField());
+        sha256TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA256", sha256CheckBox, sha256TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha384OptionPanel.setLayout(new BoxLayout(sha384OptionPanel, BoxLayout.X_AXIS));
-        sha384CheckBox = new JCheckBox("SHA384 checksum:");
-        sha384TextField = new JTextField();
-        sha384OptionPanel.add(sha384CheckBox);
-        sha384OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha384OptionPanel.add(sha384TextField);
+        sha384CheckBox = new JCheckBox("SHA384");
+        sha384TextField = UiKit.field(new JTextField());
+        sha384TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA384", sha384CheckBox, sha384TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha512OptionPanel.setLayout(new BoxLayout(sha512OptionPanel, BoxLayout.X_AXIS));
-        sha512CheckBox = new JCheckBox("SHA512 checksum:");
-        sha512TextField = new JTextField();
-        sha512OptionPanel.add(sha512CheckBox);
-        sha512OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha512OptionPanel.add(sha512TextField);
+        sha512CheckBox = new JCheckBox("SHA512");
+        sha512TextField = UiKit.field(new JTextField());
+        sha512TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA512", sha512CheckBox, sha512TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        crc32OptionPanel.setLayout(new BoxLayout(crc32OptionPanel, BoxLayout.X_AXIS));
-        crc32CheckBox = new JCheckBox("CRC32 checksum:");
+        crc32CheckBox = new JCheckBox("CRC32");
         crc32CheckBox.setSelected(true);
-        crc32TextField = new JTextField();
-        crc32OptionPanel.add(crc32CheckBox);
-        crc32OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        crc32OptionPanel.add(crc32TextField);
+        crc32TextField = UiKit.field(new JTextField());
+        crc32TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("CRC32", crc32CheckBox, crc32TextField));
     }
 
     private void createOperationPanel() {
-        operationPanel = new JPanel();
-
-        JButton compareButton = new JButton("Compare");
-        compareButton.setFocusPainted(false);
+        JButton compareButton = UiKit.primaryButton("Recalculate");
         compareButton.addActionListener(arg0 -> {
             File file = filePanel.getFile();
             if (file == null) {
@@ -174,13 +136,18 @@ public class FileChecksumPanel extends EasyChildTabbedPanel {
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setMaximum(100);
+        progressBar.setPreferredSize(new Dimension(200, 22));
 
+        JPanel actions = UiKit.actionRow(compareButton);
+        JPanel bar = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        bar.setOpaque(false);
+        bar.add(progressBar, BorderLayout.CENTER);
+        bar.add(actions, BorderLayout.EAST);
 
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.add(compareButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(progressBar);
-
+        operationPanel = new JPanel();
+        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.Y_AXIS));
+        operationPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        operationPanel.add(bar);
     }
 
     private void calculate(File file) {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/checksum/panel/StringHashPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/checksum/panel/StringHashPanel.java
@@ -2,10 +2,11 @@ package edu.jiangxin.apktoolbox.file.checksum.panel;
 
 import edu.jiangxin.apktoolbox.file.checksum.CalculateType;
 import edu.jiangxin.apktoolbox.swing.extend.EasyChildTabbedPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import org.apache.commons.codec.digest.DigestUtils;
 
 import javax.swing.*;
+import java.awt.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -38,120 +39,85 @@ public class StringHashPanel extends EasyChildTabbedPanel {
 
     @Override
     public void createUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
         createStringInputPanel();
         add(stringInputPanel);
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
         createOptionPanel();
         add(optionPanel);
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
         createOperationPanel();
         add(operationPanel);
     }
 
     private void createStringInputPanel() {
         stringInputPanel = new JPanel();
-        BoxLayout boxLayout = new BoxLayout(stringInputPanel, BoxLayout.Y_AXIS);
-        stringInputPanel.setLayout(boxLayout);
+        stringInputPanel.setLayout(new BoxLayout(stringInputPanel, BoxLayout.Y_AXIS));
+        stringInputPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        stringInputPanel.setBorder(UiKit.sectionBorder("Input"));
 
-        JLabel stringInputLabel = new JLabel("Insert string to compute hash checksum:");
         stringInputTextArea = new JTextArea(5, 4);
         stringInputTextArea.setLineWrap(true);
+        stringInputTextArea.setMargin(new Insets(UiKit.GAP_SM, UiKit.GAP_SM, UiKit.GAP_SM, UiKit.GAP_SM));
         JScrollPane stringInputScrollPanel = new JScrollPane(stringInputTextArea);
 
-        stringInputPanel.add(stringInputLabel);
-        stringInputPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        stringInputPanel.add(stringInputScrollPanel);
+        stringInputPanel.add(UiKit.formRow("String", stringInputScrollPanel));
     }
 
     private void createOptionPanel() {
         optionPanel = new JPanel();
-        BoxLayout boxLayout = new BoxLayout(optionPanel, BoxLayout.Y_AXIS);
-        optionPanel.setLayout(boxLayout);
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Results"));
 
-        JPanel stringLengthOptionPanel = new JPanel();
-        JPanel md5OptionPanel = new JPanel();
-        JPanel sha1OptionPanel = new JPanel();
-        JPanel sha256OptionPanel = new JPanel();
-        JPanel sha384OptionPanel = new JPanel();
-        JPanel sha512OptionPanel = new JPanel();
-        JPanel crc32OptionPanel = new JPanel();
+        stringLengthTextField = UiKit.field(new JTextField());
+        stringLengthTextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("Length", stringLengthTextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        optionPanel.add(stringLengthOptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(md5OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha1OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha256OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha384OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(sha512OptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(crc32OptionPanel);
-
-        stringLengthOptionPanel.setLayout(new BoxLayout(stringLengthOptionPanel, BoxLayout.X_AXIS));
-        JLabel stringLengthLabel = new JLabel("String length:");
-        stringLengthTextField = new JTextField();
-        stringLengthOptionPanel.add(stringLengthLabel);
-        stringLengthOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        stringLengthOptionPanel.add(stringLengthTextField);
-
-        md5OptionPanel.setLayout(new BoxLayout(md5OptionPanel, BoxLayout.X_AXIS));
-        md5CheckBox = new JCheckBox("MD5 checksum:");
+        md5CheckBox = new JCheckBox("MD5");
         md5CheckBox.setSelected(true);
-        md5TextField = new JTextField();
-        md5OptionPanel.add(md5CheckBox);
-        md5OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        md5OptionPanel.add(md5TextField);
+        md5TextField = UiKit.field(new JTextField());
+        md5TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("MD5", md5CheckBox, md5TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha1OptionPanel.setLayout(new BoxLayout(sha1OptionPanel, BoxLayout.X_AXIS));
-        sha1CheckBox = new JCheckBox("SHA1 checksum:");
-        sha1TextField = new JTextField();
-        sha1OptionPanel.add(sha1CheckBox);
-        sha1OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha1OptionPanel.add(sha1TextField);
+        sha1CheckBox = new JCheckBox("SHA1");
+        sha1TextField = UiKit.field(new JTextField());
+        sha1TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA1", sha1CheckBox, sha1TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha256OptionPanel.setLayout(new BoxLayout(sha256OptionPanel, BoxLayout.X_AXIS));
-        sha256CheckBox = new JCheckBox("SHA256 checksum:");
-        sha256TextField = new JTextField();
-        sha256OptionPanel.add(sha256CheckBox);
-        sha256OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha256OptionPanel.add(sha256TextField);
+        sha256CheckBox = new JCheckBox("SHA256");
+        sha256TextField = UiKit.field(new JTextField());
+        sha256TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA256", sha256CheckBox, sha256TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha384OptionPanel.setLayout(new BoxLayout(sha384OptionPanel, BoxLayout.X_AXIS));
-        sha384CheckBox = new JCheckBox("SHA384 checksum:");
-        sha384TextField = new JTextField();
-        sha384OptionPanel.add(sha384CheckBox);
-        sha384OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha384OptionPanel.add(sha384TextField);
+        sha384CheckBox = new JCheckBox("SHA384");
+        sha384TextField = UiKit.field(new JTextField());
+        sha384TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA384", sha384CheckBox, sha384TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        sha512OptionPanel.setLayout(new BoxLayout(sha512OptionPanel, BoxLayout.X_AXIS));
-        sha512CheckBox = new JCheckBox("SHA512 checksum:");
-        sha512TextField = new JTextField();
-        sha512OptionPanel.add(sha512CheckBox);
-        sha512OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        sha512OptionPanel.add(sha512TextField);
+        sha512CheckBox = new JCheckBox("SHA512");
+        sha512TextField = UiKit.field(new JTextField());
+        sha512TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("SHA512", sha512CheckBox, sha512TextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
-        crc32OptionPanel.setLayout(new BoxLayout(crc32OptionPanel, BoxLayout.X_AXIS));
-        crc32CheckBox = new JCheckBox("CRC32 checksum:");
-        crc32TextField = new JTextField();
-        crc32OptionPanel.add(crc32CheckBox);
-        crc32OptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        crc32OptionPanel.add(crc32TextField);
+        crc32CheckBox = new JCheckBox("CRC32");
+        crc32TextField = UiKit.field(new JTextField());
+        crc32TextField.setEditable(false);
+        optionPanel.add(UiKit.formRow("CRC32", crc32CheckBox, crc32TextField));
     }
 
     private void createOperationPanel() {
-        operationPanel = new JPanel();
-
-        JButton compareButton = new JButton("Compare");
-        compareButton.setFocusPainted(false);
+        JButton compareButton = UiKit.primaryButton("Calculate");
         compareButton.addActionListener(arg0 -> {
             String text = stringInputTextArea.getText();
             if (text == null) {
@@ -164,13 +130,18 @@ public class StringHashPanel extends EasyChildTabbedPanel {
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setMaximum(100);
+        progressBar.setPreferredSize(new Dimension(200, 22));
 
+        JPanel actions = UiKit.actionRow(compareButton);
+        JPanel bar = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        bar.setOpaque(false);
+        bar.add(progressBar, BorderLayout.CENTER);
+        bar.add(actions, BorderLayout.EAST);
 
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.add(compareButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(progressBar);
-
+        operationPanel = new JPanel();
+        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.Y_AXIS));
+        operationPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        operationPanel.add(bar);
     }
 
     private void calculate(String text) {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/duplicate/DuplicateSearchPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/duplicate/DuplicateSearchPanel.java
@@ -3,6 +3,7 @@ package edu.jiangxin.apktoolbox.file.duplicate;
 import edu.jiangxin.apktoolbox.utils.DateUtils;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import edu.jiangxin.apktoolbox.utils.ExcelExporter;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
@@ -12,7 +13,9 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -70,7 +73,7 @@ public class DuplicateSearchPanel extends EasyPanel {
         add(tabbedPane);
 
         createOptionPanel();
-        tabbedPane.addTab("Option", null, optionPanel, "Show Search Options");
+        tabbedPane.addTab("Options", null, optionPanel, "Show Search Options");
 
         createResultPanel();
         tabbedPane.addTab("Result", null, resultPanel, "Show Search Result");
@@ -79,13 +82,10 @@ public class DuplicateSearchPanel extends EasyPanel {
     private void createOptionPanel() {
         optionPanel = new JPanel();
         optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         fileListPanel = new FileListPanel();
         fileListPanel.initialize();
-
-        JPanel checkOptionPanel = new JPanel();
-        checkOptionPanel.setLayout(new BoxLayout(checkOptionPanel, BoxLayout.X_AXIS));
-        checkOptionPanel.setBorder(BorderFactory.createTitledBorder("Check Options"));
 
         JCheckBox isSizeChecked = new JCheckBox("Size");
         isSizeChecked.setSelected(true);
@@ -93,72 +93,60 @@ public class DuplicateSearchPanel extends EasyPanel {
         isFileNameChecked = new JCheckBox("Filename");
         isMD5Checked = new JCheckBox("MD5");
         isModifiedTimeChecked = new JCheckBox("Last Modified Time");
-        checkOptionPanel.add(isSizeChecked);
-        checkOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        checkOptionPanel.add(isFileNameChecked);
-        checkOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        checkOptionPanel.add(isMD5Checked);
-        checkOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        checkOptionPanel.add(isModifiedTimeChecked);
-        checkOptionPanel.add(Box.createHorizontalGlue());
 
-        JPanel searchOptionPanel = new JPanel();
-        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.X_AXIS));
-        searchOptionPanel.setBorder(BorderFactory.createTitledBorder("Search Options"));
+        JPanel checkOptionPanel = new JPanel();
+        checkOptionPanel.setLayout(new BoxLayout(checkOptionPanel, BoxLayout.Y_AXIS));
+        checkOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        checkOptionPanel.setBorder(UiKit.sectionBorder("Check Options"));
+        checkOptionPanel.add(UiKit.checkRow(isSizeChecked, isFileNameChecked, isMD5Checked, isModifiedTimeChecked));
 
         isHiddenFileSearched = new JCheckBox("Hidden Files");
         isRecursiveSearched = new JCheckBox("Recursive");
         isRecursiveSearched.setSelected(true);
-        JLabel suffixLabel = new JLabel("Suffix: ");
-        suffixTextField = new JTextField();
+        suffixTextField = UiKit.field(new JTextField());
         suffixTextField.setToolTipText("an array of extensions, ex. {\"java\",\"xml\"}. If this parameter is empty, all files are returned.");
-        searchOptionPanel.add(isHiddenFileSearched);
-        searchOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        searchOptionPanel.add(isRecursiveSearched);
-        searchOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        searchOptionPanel.add(suffixLabel);
-        searchOptionPanel.add(suffixTextField);
-        searchOptionPanel.add(Box.createHorizontalGlue());
 
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.setBorder(BorderFactory.createTitledBorder("Operations"));
+        JPanel searchOptionPanel = new JPanel();
+        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.Y_AXIS));
+        searchOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        searchOptionPanel.setBorder(UiKit.sectionBorder("Search Options"));
+        searchOptionPanel.add(UiKit.checkRow(isHiddenFileSearched, isRecursiveSearched));
+        searchOptionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        searchOptionPanel.add(UiKit.formRow("Suffix", suffixTextField));
 
-        JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
-
-        searchButton = new JButton("Search");
-        cancelButton = new JButton("Cancel");
+        searchButton = UiKit.primaryButton("Search");
+        cancelButton = UiKit.secondaryButton("Cancel");
         cancelButton.setEnabled(false);
         searchButton.addActionListener(new OperationButtonActionListener());
         cancelButton.addActionListener(new OperationButtonActionListener());
-        operationPanel.add(searchButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(cancelButton);
-        operationPanel.add(Box.createHorizontalGlue());
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setString("Ready");
+        progressBar.setPreferredSize(new Dimension(Constants.DEFAULT_SCROLL_PANEL_WIDTH, 22));
+        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
         optionPanel.add(fileListPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         optionPanel.add(checkOptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         optionPanel.add(searchOptionPanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(operationPanel);
-		optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
+        optionPanel.add(UiKit.actionRow(cancelButton, searchButton));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         optionPanel.add(progressBar);
     }
 
     private void createResultPanel() {
         resultPanel = new JPanel();
-        resultPanel.setLayout(new BoxLayout(resultPanel, BoxLayout.Y_AXIS));
+        resultPanel.setLayout(new BorderLayout());
+        resultPanel.setBorder(new EmptyBorder(UiKit.GAP_XS, 0, 0, 0));
 
         resultTableModel = new DuplicateFilesTableModel(new Vector<>(), DuplicateFilesConstants.COLUMN_NAMES);
         resultTable = new JTable(resultTableModel);
+        resultTable.setRowHeight(28);
+        resultTable.setShowGrid(false);
+        resultTable.setIntercellSpacing(new Dimension(0, 0));
 
         resultTable.setDefaultRenderer(Vector.class, new DuplicateFilesTableCellRenderer());
 
@@ -171,7 +159,7 @@ public class DuplicateSearchPanel extends EasyPanel {
         resultTable.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
 
         JScrollPane scrollPane = new JScrollPane(resultTable);
-        resultPanel.add(scrollPane);
+        resultPanel.add(scrollPane, BorderLayout.CENTER);
     }
 
     private String getComparedKey(File file) {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/password/recovery/RecoveryPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/password/recovery/RecoveryPanel.java
@@ -107,16 +107,22 @@ public final class RecoveryPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setLayout(new BorderLayout(UiKit.GAP_MD, UiKit.GAP_MD));
         setBorder(UiKit.sectionBorder("Password Recovery"));
 
+        JPanel form = new JPanel();
+        form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
+        form.setAlignmentX(Component.LEFT_ALIGNMENT);
+        form.setMaximumSize(new Dimension(980, Integer.MAX_VALUE));
+
         createOptionPanel();
-        add(optionPanel);
-        add(Box.createVerticalStrut(UiKit.GAP_MD));
+        form.add(optionPanel);
+        form.add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
-        add(operationPanel);
+        form.add(operationPanel);
+
+        add(form, BorderLayout.NORTH);
 
         timer = new Timer(1000, e -> {
             if (currentState == State.WORKING) {
@@ -129,8 +135,17 @@ public final class RecoveryPanel extends EasyPanel {
     }
 
     private void createOptionPanel() {
-        optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel = new JPanel(new GridBagLayout());
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Input"));
+
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.gridx = 0;
+        gc.gridy = 0;
+        gc.weightx = 1;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.anchor = GridBagConstraints.WEST;
+        gc.insets = new Insets(2, 8, 2, 8);
 
         checkerTypeComboBox = new JComboBox<>();
         checkerTypeComboBox.addItem(new ThirdParty7ZipChecker());
@@ -159,7 +174,7 @@ public final class RecoveryPanel extends EasyPanel {
             return;
         }
 
-        recoveryFilePanel = new FilePanel("Choose Recovery File");
+        recoveryFilePanel = new FilePanel("Browse...");
         recoveryFilePanel.initialize();
         recoveryFilePanel.setDescriptionAndFileExtensions(fileChecker.getFileDescription(), fileChecker.getFileExtensions());
 
@@ -174,126 +189,161 @@ public final class RecoveryPanel extends EasyPanel {
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
-        String text = numberFormat.format(0);
-        progressBar.setString(text);
+        progressBar.setString(numberFormat.format(0));
         progressBar.setPreferredSize(new Dimension(0, 22));
         progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
-        checkerTypeComboBox.setPreferredSize(new Dimension(320, UiKit.FIELD_HEIGHT));
-        checkerTypeComboBox.setMaximumSize(new Dimension(320, UiKit.FIELD_HEIGHT));
+        optionPanel.add(gridRow("Archive Type", checkerTypeComboBox), gc);
+        gc.gridy++;
+        optionPanel.add(gridRow("File", recoveryFilePanel), gc);
+        gc.gridy++;
+        gc.fill = GridBagConstraints.BOTH;
+        gc.weighty = 1;
+        optionPanel.add(categoryTabbedPane, gc);
+        gc.gridy++;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.weighty = 0;
+        optionPanel.add(progressBar, gc);
+    }
 
-        optionPanel.add(UiKit.formRow("Archive Type", checkerTypeComboBox));
-        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
-        optionPanel.add(UiKit.formRow("File", recoveryFilePanel));
-        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
-        optionPanel.add(categoryTabbedPane);
-        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
-        optionPanel.add(progressBar);
+    private JPanel gridRow(String label, JComponent field) {
+        JPanel row = new JPanel(new GridBagLayout());
+        row.setOpaque(false);
+        GridBagConstraints c = new GridBagConstraints();
+        c.gridy = 0;
+        c.insets = new Insets(2, 0, 2, 0);
+        c.anchor = GridBagConstraints.WEST;
+        c.fill = GridBagConstraints.NONE;
+        c.weightx = 0;
+
+        JLabel jlabel = new JLabel(label);
+        jlabel.setPreferredSize(new Dimension(UiKit.LABEL_WIDTH, UiKit.FIELD_HEIGHT));
+        c.gridx = 0;
+        row.add(jlabel, c);
+
+        c.gridx = 1;
+        c.weightx = 1;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        if (field instanceof JComboBox<?> combo) {
+            combo.setPreferredSize(new Dimension(Math.max(combo.getPreferredSize().width, 280), UiKit.FIELD_HEIGHT));
+            combo.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT));
+        }
+        row.add(field, c);
+        return row;
     }
 
     private void createBruteForcePanel() {
         bruteForceCategoryPanel = new JPanel();
-
-        JPanel topLevelPanel = new JPanel();
-        topLevelPanel.setLayout(new BoxLayout(topLevelPanel, BoxLayout.Y_AXIS));
-        bruteForceCategoryPanel.add(topLevelPanel);
-
-        JPanel charsetPanel = new JPanel();
-        charsetPanel.setLayout(new BoxLayout(charsetPanel, BoxLayout.X_AXIS));
-
-        JPanel passwordLengthPanel = new JPanel();
-        passwordLengthPanel.setLayout(new BoxLayout(passwordLengthPanel, BoxLayout.X_AXIS));
-
-        topLevelPanel.add(charsetPanel);
-        topLevelPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        topLevelPanel.add(passwordLengthPanel);
+        bruteForceCategoryPanel.setLayout(new BoxLayout(bruteForceCategoryPanel, BoxLayout.Y_AXIS));
+        bruteForceCategoryPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        bruteForceCategoryPanel.setBorder(UiKit.sectionBorder("Charset & Length"));
 
         numberCheckBox = new JCheckBox("Number");
         numberCheckBox.setSelected(true);
-        lowercaseLetterCheckBox = new JCheckBox("Lowercase Letter");
-        uppercaseLetterCheckBox = new JCheckBox("Uppercase Letter");
-        userIncludedCheckBox = new JCheckBox("User-defined");
-        userIncludedTextField = new JTextField(10);
-        userExcludedCheckBox = new JCheckBox("User-excluded");
-        userExcludedTextField = new JTextField(10);
+        lowercaseLetterCheckBox = new JCheckBox("Lowercase");
+        uppercaseLetterCheckBox = new JCheckBox("Uppercase");
+        userIncludedCheckBox = new JCheckBox("Include");
+        userIncludedTextField = UiKit.field(new JTextField());
+        userIncludedTextField.setColumns(8);
+        userExcludedCheckBox = new JCheckBox("Exclude");
+        userExcludedTextField = UiKit.field(new JTextField());
+        userExcludedTextField.setColumns(8);
 
-
-        charsetPanel.add(numberCheckBox);
-        charsetPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        charsetPanel.add(lowercaseLetterCheckBox);
-        charsetPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        charsetPanel.add(uppercaseLetterCheckBox);
-        charsetPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        charsetPanel.add(userIncludedCheckBox);
-        charsetPanel.add(userIncludedTextField);
-        charsetPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        charsetPanel.add(userExcludedCheckBox);
-        charsetPanel.add(userExcludedTextField);
-
-        JLabel minLabel = new JLabel("Minimum Length: ");
-        JLabel maxLabel = new JLabel("Maximum Length: ");
+        bruteForceCategoryPanel.add(UiKit.checkRow(
+                numberCheckBox, lowercaseLetterCheckBox, uppercaseLetterCheckBox));
+        bruteForceCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        bruteForceCategoryPanel.add(UiKit.checkRow(
+                userIncludedCheckBox, userIncludedTextField,
+                userExcludedCheckBox, userExcludedTextField));
+        bruteForceCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
         minSpinner = new JSpinner();
         minSpinner.setModel(new SpinnerNumberModel(1, 1, 9, 1));
-        minSpinner.setToolTipText("Minimum Length");
+        minSpinner.setToolTipText("Minimum password length");
+        minSpinner.setPreferredSize(new Dimension(72, UiKit.FIELD_HEIGHT));
+        minSpinner.setMaximumSize(new Dimension(72, UiKit.FIELD_HEIGHT));
 
         maxSpinner = new JSpinner();
         maxSpinner.setModel(new SpinnerNumberModel(6, 1, 9, 1));
-        maxSpinner.setToolTipText("Maximum Length");
+        maxSpinner.setToolTipText("Maximum password length");
+        maxSpinner.setPreferredSize(new Dimension(72, UiKit.FIELD_HEIGHT));
+        maxSpinner.setMaximumSize(new Dimension(72, UiKit.FIELD_HEIGHT));
 
-        passwordLengthPanel.add(minLabel);
-        passwordLengthPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        passwordLengthPanel.add(minSpinner);
-        passwordLengthPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        passwordLengthPanel.add(maxLabel);
-        passwordLengthPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        passwordLengthPanel.add(maxSpinner);
+        JPanel lengthRow = new JPanel();
+        lengthRow.setLayout(new BoxLayout(lengthRow, BoxLayout.X_AXIS));
+        lengthRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+        lengthRow.setOpaque(false);
+        lengthRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT + GAP_XS_PAD()));
+        lengthRow.add(UiKit.mutedLabel("Length"));
+        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_SM));
+        lengthRow.add(UiKit.mutedLabel("Min"));
+        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_XS));
+        lengthRow.add(minSpinner);
+        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_MD));
+        lengthRow.add(UiKit.mutedLabel("Max"));
+        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_XS));
+        lengthRow.add(maxSpinner);
+        lengthRow.add(Box.createHorizontalGlue());
+        bruteForceCategoryPanel.add(lengthRow);
+    }
+
+    private int GAP_XS_PAD() {
+        return UiKit.GAP_XS * 2;
     }
 
     private void createDictionaryPanel() {
         dictionaryCategoryPanel = new JPanel();
+        dictionaryCategoryPanel.setLayout(new BoxLayout(dictionaryCategoryPanel, BoxLayout.Y_AXIS));
+        dictionaryCategoryPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        dictionaryCategoryPanel.setBorder(UiKit.sectionBorder("Dictionary"));
 
-        JPanel topLevelPanel = new JPanel();
-        topLevelPanel.setLayout(new BoxLayout(topLevelPanel, BoxLayout.Y_AXIS));
-        dictionaryCategoryPanel.add(topLevelPanel);
-
-        dictionaryFilePanel = new FilePanel("Choose Dictionary File");
+        dictionaryFilePanel = new FilePanel("Browse...");
         dictionaryFilePanel.initialize();
         dictionaryFilePanel.setDescriptionAndFileExtensions("*.dic;*.txt", new String[]{"dic", "txt"});
 
-        JPanel threadPanel = new JPanel();
-        threadPanel.setLayout(new BoxLayout(threadPanel, BoxLayout.X_AXIS));
-
-        topLevelPanel.add(dictionaryFilePanel);
-        topLevelPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        topLevelPanel.add(threadPanel);
-
-        isUseMultiThreadCheckBox = new JCheckBox("Use Multi-thread");
+        isUseMultiThreadCheckBox = new JCheckBox("Use multi-thread");
         isUseMultiThreadCheckBox.setSelected(true);
 
-        threadPanel.add(isUseMultiThreadCheckBox);
+        dictionaryCategoryPanel.add(UiKit.formRow("Dictionary", dictionaryFilePanel));
+        dictionaryCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        dictionaryCategoryPanel.add(UiKit.checkRow(isUseMultiThreadCheckBox));
     }
 
     private void createOperationPanel() {
+        startButton = UiKit.primaryButton("Start");
+        stopButton = UiKit.secondaryButton("Stop");
+        stopButton.setEnabled(false);
+        currentStateLabel = UiKit.mutedLabel("State: IDLE");
+        currentPasswordLabel = UiKit.mutedLabel("Trying: —");
+        currentSpeedLabel = UiKit.mutedLabel("Speed: 0 passwords/s");
+
+        JPanel statusPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, UiKit.GAP_MD, 4));
+        statusPanel.setOpaque(false);
+        statusPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        statusPanel.add(currentStateLabel);
+        statusPanel.add(currentPasswordLabel);
+        statusPanel.add(currentSpeedLabel);
+
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT, UiKit.GAP_SM, 0));
+        actions.setOpaque(false);
+        actions.setAlignmentX(Component.LEFT_ALIGNMENT);
+        actions.add(stopButton);
+        actions.add(startButton);
+
+        JPanel bar = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        bar.setOpaque(false);
+        bar.setAlignmentX(Component.LEFT_ALIGNMENT);
+        bar.setPreferredSize(new Dimension(900, 40));
+        bar.setMinimumSize(new Dimension(400, 40));
+        bar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 44));
+        bar.add(statusPanel, BorderLayout.WEST);
+        bar.add(actions, BorderLayout.EAST);
+
         operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-
-        startButton = new JButton("Start");
-        stopButton = new JButton("Stop");
-        currentStateLabel = new JLabel("State: IDLE");
-        currentPasswordLabel = new JLabel("Trying: ");
-        currentSpeedLabel = new JLabel("Speed: 0 passwords/s");
-
-        operationPanel.add(startButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(stopButton);
-        operationPanel.add(Box.createHorizontalStrut(2 * Constants.DEFAULT_X_BORDER));
-        operationPanel.add(currentStateLabel);
-        operationPanel.add(Box.createHorizontalStrut(2 * Constants.DEFAULT_X_BORDER));
-        operationPanel.add(currentPasswordLabel);
-        operationPanel.add(Box.createHorizontalStrut(2 * Constants.DEFAULT_X_BORDER));
-        operationPanel.add(currentSpeedLabel);
-        operationPanel.add(Box.createHorizontalGlue());
+        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.Y_AXIS));
+        operationPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        operationPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 48));
+        operationPanel.add(bar);
 
         startButton.addActionListener(e -> startExecutorService.submit(this::onStart));
         stopButton.addActionListener(e -> stopExecutorService.submit(this::onStop));

--- a/src/main/java/edu/jiangxin/apktoolbox/file/password/recovery/RecoveryPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/password/recovery/RecoveryPanel.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
@@ -107,22 +108,17 @@ public final class RecoveryPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        setLayout(new BorderLayout(UiKit.GAP_MD, UiKit.GAP_MD));
-        setBorder(UiKit.sectionBorder("Password Recovery"));
-
-        JPanel form = new JPanel();
-        form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
-        form.setAlignmentX(Component.LEFT_ALIGNMENT);
-        form.setMaximumSize(new Dimension(980, Integer.MAX_VALUE));
+        setLayout(new BorderLayout(0, 8));
+        setBorder(new EmptyBorder(8, 8, 8, 8));
 
         createOptionPanel();
-        form.add(optionPanel);
-        form.add(Box.createVerticalStrut(UiKit.GAP_MD));
-
         createOperationPanel();
-        form.add(operationPanel);
 
-        add(form, BorderLayout.NORTH);
+        JPanel main = new JPanel(new BorderLayout(0, 12));
+        main.setOpaque(false);
+        main.add(optionPanel, BorderLayout.NORTH);
+        main.add(operationPanel, BorderLayout.SOUTH);
+        add(main, BorderLayout.NORTH);
 
         timer = new Timer(1000, e -> {
             if (currentState == State.WORKING) {
@@ -136,16 +132,14 @@ public final class RecoveryPanel extends EasyPanel {
 
     private void createOptionPanel() {
         optionPanel = new JPanel(new GridBagLayout());
-        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        optionPanel.setBorder(UiKit.sectionBorder("Input"));
+        optionPanel.setOpaque(false);
 
         GridBagConstraints gc = new GridBagConstraints();
         gc.gridx = 0;
-        gc.gridy = 0;
-        gc.weightx = 1;
-        gc.fill = GridBagConstraints.HORIZONTAL;
-        gc.anchor = GridBagConstraints.WEST;
-        gc.insets = new Insets(2, 8, 2, 8);
+        gc.weightx = 0;
+        gc.fill = GridBagConstraints.NONE;
+        gc.anchor = GridBagConstraints.LINE_END;
+        gc.insets = new Insets(4, 8, 4, 8);
 
         checkerTypeComboBox = new JComboBox<>();
         checkerTypeComboBox.addItem(new ThirdParty7ZipChecker());
@@ -178,124 +172,170 @@ public final class RecoveryPanel extends EasyPanel {
         recoveryFilePanel.initialize();
         recoveryFilePanel.setDescriptionAndFileExtensions(fileChecker.getFileDescription(), fileChecker.getFileExtensions());
 
-        categoryTabbedPane = new JTabbedPane();
+        checkerTypeComboBox.setPreferredSize(new Dimension(420, UiKit.FIELD_HEIGHT));
+        checkerTypeComboBox.setMinimumSize(new Dimension(260, UiKit.FIELD_HEIGHT));
+        checkerTypeComboBox.setMaximumSize(new Dimension(520, UiKit.FIELD_HEIGHT));
 
+        JLabel archiveLabel = mutedRowLabel("Archive type");
+        gc.gridy = 0;
+        gc.gridx = 0;
+        optionPanel.add(archiveLabel, gc);
+        gc.gridx = 1;
+        gc.weightx = 1;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.anchor = GridBagConstraints.LINE_START;
+        optionPanel.add(checkerTypeComboBox, gc);
+
+        JLabel fileLabel = mutedRowLabel("Encrypted file");
+        gc.gridy = 1;
+        gc.gridx = 0;
+        gc.weightx = 0;
+        gc.fill = GridBagConstraints.NONE;
+        gc.anchor = GridBagConstraints.LINE_END;
+        optionPanel.add(fileLabel, gc);
+        gc.gridx = 1;
+        gc.weightx = 1;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.anchor = GridBagConstraints.LINE_START;
+        optionPanel.add(recoveryFilePanel, gc);
+
+        categoryTabbedPane = new JTabbedPane();
         createBruteForcePanel();
         categoryTabbedPane.addTab("Brute Force", null, bruteForceCategoryPanel, "Brute Force");
         categoryTabbedPane.setSelectedIndex(0);
-
         createDictionaryPanel();
         categoryTabbedPane.addTab("Dictionary", null, dictionaryCategoryPanel, "Dictionary");
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setString(numberFormat.format(0));
-        progressBar.setPreferredSize(new Dimension(0, 22));
-        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
+        progressBar.setPreferredSize(new Dimension(0, 18));
 
-        optionPanel.add(gridRow("Archive Type", checkerTypeComboBox), gc);
-        gc.gridy++;
-        optionPanel.add(gridRow("File", recoveryFilePanel), gc);
-        gc.gridy++;
-        gc.fill = GridBagConstraints.BOTH;
+        gc.gridy = 2;
+        gc.gridx = 0;
+        gc.gridwidth = 2;
+        gc.weightx = 1;
         gc.weighty = 1;
+        gc.fill = GridBagConstraints.BOTH;
+        gc.insets = new Insets(10, 8, 4, 8);
         optionPanel.add(categoryTabbedPane, gc);
-        gc.gridy++;
-        gc.fill = GridBagConstraints.HORIZONTAL;
+
+        gc.gridy = 3;
         gc.weighty = 0;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.insets = new Insets(4, 8, 0, 8);
         optionPanel.add(progressBar, gc);
     }
 
-    private JPanel gridRow(String label, JComponent field) {
-        JPanel row = new JPanel(new GridBagLayout());
-        row.setOpaque(false);
-        GridBagConstraints c = new GridBagConstraints();
-        c.gridy = 0;
-        c.insets = new Insets(2, 0, 2, 0);
-        c.anchor = GridBagConstraints.WEST;
-        c.fill = GridBagConstraints.NONE;
-        c.weightx = 0;
-
-        JLabel jlabel = new JLabel(label);
-        jlabel.setPreferredSize(new Dimension(UiKit.LABEL_WIDTH, UiKit.FIELD_HEIGHT));
-        c.gridx = 0;
-        row.add(jlabel, c);
-
-        c.gridx = 1;
-        c.weightx = 1;
-        c.fill = GridBagConstraints.HORIZONTAL;
-        if (field instanceof JComboBox<?> combo) {
-            combo.setPreferredSize(new Dimension(Math.max(combo.getPreferredSize().width, 280), UiKit.FIELD_HEIGHT));
-            combo.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT));
-        }
-        row.add(field, c);
-        return row;
+    private JLabel mutedRowLabel(String text) {
+        JLabel label = new JLabel(text);
+        label.setForeground(UiKit.MUTED);
+        label.setPreferredSize(new Dimension(110, UiKit.FIELD_HEIGHT));
+        label.setMinimumSize(new Dimension(110, UiKit.FIELD_HEIGHT));
+        label.setMaximumSize(new Dimension(110, UiKit.FIELD_HEIGHT));
+        return label;
     }
 
     private void createBruteForcePanel() {
         bruteForceCategoryPanel = new JPanel();
         bruteForceCategoryPanel.setLayout(new BoxLayout(bruteForceCategoryPanel, BoxLayout.Y_AXIS));
         bruteForceCategoryPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        bruteForceCategoryPanel.setBorder(UiKit.sectionBorder("Charset & Length"));
+        bruteForceCategoryPanel.setBorder(new EmptyBorder(UiKit.GAP_SM, 20, UiKit.GAP_XS, 20));
 
         numberCheckBox = new JCheckBox("Number");
         numberCheckBox.setSelected(true);
-        lowercaseLetterCheckBox = new JCheckBox("Lowercase");
-        uppercaseLetterCheckBox = new JCheckBox("Uppercase");
+        lowercaseLetterCheckBox = new JCheckBox("Lowercase letters");
+        uppercaseLetterCheckBox = new JCheckBox("Uppercase letters");
+
+        JPanel charsetRow = new JPanel(new FlowLayout(FlowLayout.LEFT, UiKit.GAP_LG, UiKit.GAP_XS));
+        charsetRow.setOpaque(false);
+        charsetRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+        charsetRow.add(numberCheckBox);
+        charsetRow.add(lowercaseLetterCheckBox);
+        charsetRow.add(uppercaseLetterCheckBox);
+        bruteForceCategoryPanel.add(charsetRow);
+        bruteForceCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+
         userIncludedCheckBox = new JCheckBox("Include");
         userIncludedTextField = UiKit.field(new JTextField());
-        userIncludedTextField.setColumns(8);
         userExcludedCheckBox = new JCheckBox("Exclude");
         userExcludedTextField = UiKit.field(new JTextField());
-        userExcludedTextField.setColumns(8);
 
-        bruteForceCategoryPanel.add(UiKit.checkRow(
-                numberCheckBox, lowercaseLetterCheckBox, uppercaseLetterCheckBox));
-        bruteForceCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
-        bruteForceCategoryPanel.add(UiKit.checkRow(
-                userIncludedCheckBox, userIncludedTextField,
-                userExcludedCheckBox, userExcludedTextField));
+        JPanel customRow = new JPanel(new GridBagLayout());
+        customRow.setOpaque(false);
+        customRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.gridy = 0;
+        gc.insets = new Insets(0, 0, 0, UiKit.GAP_MD);
+        gc.anchor = GridBagConstraints.WEST;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+
+        gc.gridx = 0;
+        gc.weightx = 0;
+        customRow.add(userIncludedCheckBox, gc);
+        gc.gridx = 1;
+        gc.weightx = 1;
+        customRow.add(userIncludedTextField, gc);
+        gc.gridx = 2;
+        gc.weightx = 0;
+        customRow.add(userExcludedCheckBox, gc);
+        gc.gridx = 3;
+        gc.weightx = 1;
+        customRow.add(userExcludedTextField, gc);
+
+        JPanel customLine = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        customLine.setOpaque(false);
+        customLine.setAlignmentX(Component.LEFT_ALIGNMENT);
+        customLine.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT + 4));
+        JLabel customLabel = new JLabel("Custom");
+        customLabel.setForeground(UiKit.MUTED);
+        customLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+        customLabel.setPreferredSize(new Dimension(120, UiKit.FIELD_HEIGHT));
+        customLabel.setMinimumSize(new Dimension(120, UiKit.FIELD_HEIGHT));
+        customLine.add(customLabel, BorderLayout.WEST);
+        customLine.add(customRow, BorderLayout.CENTER);
+        bruteForceCategoryPanel.add(customLine);
         bruteForceCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
 
         minSpinner = new JSpinner();
         minSpinner.setModel(new SpinnerNumberModel(1, 1, 9, 1));
         minSpinner.setToolTipText("Minimum password length");
-        minSpinner.setPreferredSize(new Dimension(72, UiKit.FIELD_HEIGHT));
-        minSpinner.setMaximumSize(new Dimension(72, UiKit.FIELD_HEIGHT));
+        minSpinner.setPreferredSize(new Dimension(64, UiKit.FIELD_HEIGHT));
+        minSpinner.setMinimumSize(new Dimension(64, UiKit.FIELD_HEIGHT));
+        minSpinner.setMaximumSize(new Dimension(64, UiKit.FIELD_HEIGHT));
 
         maxSpinner = new JSpinner();
         maxSpinner.setModel(new SpinnerNumberModel(6, 1, 9, 1));
         maxSpinner.setToolTipText("Maximum password length");
-        maxSpinner.setPreferredSize(new Dimension(72, UiKit.FIELD_HEIGHT));
-        maxSpinner.setMaximumSize(new Dimension(72, UiKit.FIELD_HEIGHT));
+        maxSpinner.setPreferredSize(new Dimension(64, UiKit.FIELD_HEIGHT));
+        maxSpinner.setMinimumSize(new Dimension(64, UiKit.FIELD_HEIGHT));
+        maxSpinner.setMaximumSize(new Dimension(64, UiKit.FIELD_HEIGHT));
 
-        JPanel lengthRow = new JPanel();
-        lengthRow.setLayout(new BoxLayout(lengthRow, BoxLayout.X_AXIS));
-        lengthRow.setAlignmentX(Component.LEFT_ALIGNMENT);
-        lengthRow.setOpaque(false);
-        lengthRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT + GAP_XS_PAD()));
-        lengthRow.add(UiKit.mutedLabel("Length"));
-        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_SM));
-        lengthRow.add(UiKit.mutedLabel("Min"));
-        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_XS));
-        lengthRow.add(minSpinner);
-        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_MD));
-        lengthRow.add(UiKit.mutedLabel("Max"));
-        lengthRow.add(Box.createHorizontalStrut(UiKit.GAP_XS));
-        lengthRow.add(maxSpinner);
-        lengthRow.add(Box.createHorizontalGlue());
-        bruteForceCategoryPanel.add(lengthRow);
-    }
+        JPanel lengthControls = new JPanel(new FlowLayout(FlowLayout.LEFT, UiKit.GAP_SM, 0));
+        lengthControls.setOpaque(false);
+        lengthControls.add(new JLabel("Min"));
+        lengthControls.add(minSpinner);
+        lengthControls.add(Box.createHorizontalStrut(UiKit.GAP_MD));
+        lengthControls.add(new JLabel("Max"));
+        lengthControls.add(maxSpinner);
 
-    private int GAP_XS_PAD() {
-        return UiKit.GAP_XS * 2;
+        JPanel lengthLine = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        lengthLine.setOpaque(false);
+        lengthLine.setAlignmentX(Component.LEFT_ALIGNMENT);
+        lengthLine.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT + 4));
+        JLabel lengthLabel = new JLabel("Length");
+        lengthLabel.setForeground(UiKit.MUTED);
+        lengthLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+        lengthLabel.setPreferredSize(new Dimension(120, UiKit.FIELD_HEIGHT));
+        lengthLabel.setMinimumSize(new Dimension(120, UiKit.FIELD_HEIGHT));
+        lengthLine.add(lengthLabel, BorderLayout.WEST);
+        lengthLine.add(lengthControls, BorderLayout.CENTER);
+        bruteForceCategoryPanel.add(lengthLine);
     }
 
     private void createDictionaryPanel() {
-        dictionaryCategoryPanel = new JPanel();
-        dictionaryCategoryPanel.setLayout(new BoxLayout(dictionaryCategoryPanel, BoxLayout.Y_AXIS));
-        dictionaryCategoryPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        dictionaryCategoryPanel.setBorder(UiKit.sectionBorder("Dictionary"));
+        dictionaryCategoryPanel = new JPanel(new GridBagLayout());
+        dictionaryCategoryPanel.setBorder(new EmptyBorder(8, 8, 8, 8));
 
         dictionaryFilePanel = new FilePanel("Browse...");
         dictionaryFilePanel.initialize();
@@ -304,9 +344,24 @@ public final class RecoveryPanel extends EasyPanel {
         isUseMultiThreadCheckBox = new JCheckBox("Use multi-thread");
         isUseMultiThreadCheckBox.setSelected(true);
 
-        dictionaryCategoryPanel.add(UiKit.formRow("Dictionary", dictionaryFilePanel));
-        dictionaryCategoryPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
-        dictionaryCategoryPanel.add(UiKit.checkRow(isUseMultiThreadCheckBox));
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.gridy = 0;
+        gc.gridx = 0;
+        gc.insets = new Insets(4, 4, 4, 8);
+        gc.anchor = GridBagConstraints.LINE_END;
+        dictionaryCategoryPanel.add(mutedRowLabel("Wordlist"), gc);
+        gc.gridx = 1;
+        gc.weightx = 1;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.anchor = GridBagConstraints.LINE_START;
+        dictionaryCategoryPanel.add(dictionaryFilePanel, gc);
+
+        gc.gridy = 1;
+        gc.gridx = 0;
+        gc.gridwidth = 2;
+        gc.anchor = GridBagConstraints.LINE_START;
+        gc.insets = new Insets(8, 4, 4, 8);
+        dictionaryCategoryPanel.add(isUseMultiThreadCheckBox, gc);
     }
 
     private void createOperationPanel() {

--- a/src/main/java/edu/jiangxin/apktoolbox/file/password/recovery/RecoveryPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/password/recovery/RecoveryPanel.java
@@ -9,6 +9,7 @@ import edu.jiangxin.apktoolbox.file.password.recovery.checker.thirdparty.ThirdPa
 import edu.jiangxin.apktoolbox.file.password.recovery.checker.thirdparty.ThirdPartyWinRarChecker;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.filepanel.FilePanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -106,12 +107,13 @@ public final class RecoveryPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Password Recovery"));
 
         createOptionPanel();
         add(optionPanel);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
         add(operationPanel);
@@ -174,13 +176,18 @@ public final class RecoveryPanel extends EasyPanel {
         progressBar.setStringPainted(true);
         String text = numberFormat.format(0);
         progressBar.setString(text);
+        progressBar.setPreferredSize(new Dimension(0, 22));
+        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
-        optionPanel.add(checkerTypeComboBox);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        optionPanel.add(recoveryFilePanel);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        checkerTypeComboBox.setPreferredSize(new Dimension(320, UiKit.FIELD_HEIGHT));
+        checkerTypeComboBox.setMaximumSize(new Dimension(320, UiKit.FIELD_HEIGHT));
+
+        optionPanel.add(UiKit.formRow("Archive Type", checkerTypeComboBox));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.formRow("File", recoveryFilePanel));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         optionPanel.add(categoryTabbedPane);
-        optionPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         optionPanel.add(progressBar);
     }
 

--- a/src/main/java/edu/jiangxin/apktoolbox/file/zhconvert/ZhConvertPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/file/zhconvert/ZhConvertPanel.java
@@ -3,6 +3,7 @@ package edu.jiangxin.apktoolbox.file.zhconvert;
 import com.github.houbb.opencc4j.util.ZhConverterUtil;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -49,14 +50,11 @@ public class ZhConvertPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        // JSplitPanel只能用BorderLayout，JFrame默认是BorderLayout，JPanel默认是BoxLayout
-        BorderLayout boxLayout = new BorderLayout();
-        setLayout(boxLayout);
+        setLayout(new BorderLayout());
+        setBorder(BorderFactory.createEmptyBorder(UiKit.GAP_SM, UiKit.GAP_SM, UiKit.GAP_SM, UiKit.GAP_SM));
 
         createNorthPanel();
         add(northPanel, BorderLayout.NORTH);
-
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
 
         createCenterPanel();
         add(centerPanel, BorderLayout.CENTER);
@@ -65,81 +63,89 @@ public class ZhConvertPanel extends EasyPanel {
     private void createNorthPanel() {
         northPanel = new JPanel();
         northPanel.setLayout(new BoxLayout(northPanel, BoxLayout.Y_AXIS));
+        northPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         fileListPanel = new FileListPanel();
         fileListPanel.initialize();
         northPanel.add(fileListPanel);
-        northPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        northPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         JPanel optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Options"));
         northPanel.add(optionPanel);
 
-        JLabel suffixLabel = new JLabel("Suffix:");
-        suffixTextField = new JTextField();
+        suffixTextField = UiKit.field(new JTextField());
         suffixTextField.setToolTipText("an array of extensions, ex. {\"java\",\"xml\"}. If this parameter is empty, all files are returned.");
         suffixTextField.setText(conf.getString("osconvert.suffix"));
-        optionPanel.add(suffixLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        optionPanel.add(suffixTextField);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
         recursiveCheckBox = new JCheckBox("Recursive");
         recursiveCheckBox.setSelected(true);
-        optionPanel.add(recursiveCheckBox);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
 
         comboBox = new JComboBox<>();
         comboBox.addItem(Constants.zhSimple2zhTw);
         comboBox.addItem(Constants.zhTw2zhSimple);
-        optionPanel.add(comboBox);
+        comboBox.setPreferredSize(new Dimension(180, UiKit.FIELD_HEIGHT));
+        comboBox.setMaximumSize(new Dimension(180, UiKit.FIELD_HEIGHT));
 
-        JButton convertBtn = new JButton("确认转换");
+        optionPanel.add(UiKit.formRow("Suffix", suffixTextField));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.formRow("Mode", comboBox));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        optionPanel.add(UiKit.checkRow(recursiveCheckBox));
+        optionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+
+        JButton convertBtn = UiKit.primaryButton("Convert");
         convertBtn.addActionListener(new ConvertBtnActionListener());
-        northPanel.add(convertBtn);
-
-        JFileChooser fileChooser = new JFileChooser();
-        fileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+        optionPanel.add(UiKit.actionRow(convertBtn));
     }
 
     private void createCenterPanel() {
         JPanel centerLeftTopPanel = new JPanel();
         centerLeftTopPanel.setLayout(new BoxLayout(centerLeftTopPanel, BoxLayout.Y_AXIS));
+        centerLeftTopPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        centerLeftTopPanel.setBorder(UiKit.sectionBorder("Custom Phrase Rules"));
 
-        JPanel keyValuePanel = new JPanel();
-        keyValuePanel.setLayout(new BoxLayout(keyValuePanel, BoxLayout.X_AXIS));
-        centerLeftTopPanel.add(keyValuePanel);
+        JPanel keyValuePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        keyValuePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        keyValuePanel.setOpaque(false);
 
-        keyText = new JTextField(10);
+        keyText = UiKit.field(new JTextField(12));
         keyValuePanel.add(keyText);
+        keyValuePanel.add(Box.createHorizontalStrut(UiKit.GAP_SM));
 
-        valueText = new JTextField(10);
+        valueText = UiKit.field(new JTextField(12));
         keyValuePanel.add(valueText);
+        keyValuePanel.add(Box.createHorizontalStrut(UiKit.GAP_SM));
 
-        JButton saveBtn = new JButton("添加词组定义");
+        JButton saveBtn = UiKit.secondaryButton("Add Rule");
         saveBtn.addActionListener(new SaveBtnActionListener());
-        centerLeftTopPanel.add(saveBtn);
+        keyValuePanel.add(saveBtn);
+        centerLeftTopPanel.add(keyValuePanel);
 
         JScrollPane centerLeftBottomPanel = new JScrollPane();
         textArea = new JTextArea();
-        textArea.setMargin(new Insets(10, 10, 10, 10));
-        //自动换行
+        textArea.setMargin(new Insets(UiKit.GAP_MD, UiKit.GAP_MD, UiKit.GAP_MD, UiKit.GAP_MD));
         textArea.setLineWrap(true);
         textArea.setEditable(false);
-        centerLeftBottomPanel.add(textArea);
-
-        //垂直滚动条自动出现
+        centerLeftBottomPanel.setViewportView(textArea);
         centerLeftBottomPanel.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        centerLeftBottomPanel.setBorder(UiKit.sectionBorder("Conversion Log"));
         JSplitPane centerLeftSplitPanel = new JSplitPane(JSplitPane.VERTICAL_SPLIT, centerLeftTopPanel, centerLeftBottomPanel);
+        centerLeftSplitPanel.setResizeWeight(0.15);
+        centerLeftSplitPanel.setContinuousLayout(true);
 
         transformList = new JList<>();
+        transformList.setFixedCellHeight(26);
         refreshListData();
-        transformList.setFont(new Font("Dialog", 1, 18));
-        transformList.setBorder(BorderFactory.createTitledBorder("词组转换定义"));
+        transformList.setBorder(UiKit.sectionBorder("Phrase Dictionary"));
         JScrollPane centerRightScrollPanel = new JScrollPane(transformList);
 
         centerPanel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, centerLeftSplitPanel, centerRightScrollPanel);
         centerPanel.setDividerLocation(0.7f);
+        centerPanel.setContinuousLayout(true);
+        centerPanel.setBorder(BorderFactory.createEmptyBorder());
     }
 
     private final class ConvertBtnActionListener implements ActionListener {
@@ -147,7 +153,7 @@ public class ZhConvertPanel extends EasyPanel {
         public void actionPerformed(ActionEvent e) {
             new Thread(() -> {
                 String converType = comboBox.getSelectedItem().toString();
-                System.out.println(converType);
+                logger.info("convert type: {}", converType);
 
                 List<File> fileList = new ArrayList<>();
                 for (File file : fileListPanel.getFileList()) {
@@ -164,12 +170,12 @@ public class ZhConvertPanel extends EasyPanel {
                 textArea.setCaretPosition(textArea.getText().length());
                 try {
                     scanFolderAndConver(fileList, converType, textArea);
-                    JOptionPane.showMessageDialog(getFrame(), "转换成功" , "提示",JOptionPane.WARNING_MESSAGE);
-                    textArea.append("done..." + "\n");
+                    JOptionPane.showMessageDialog(getFrame(), "Convert finished", "Info", JOptionPane.INFORMATION_MESSAGE);
+                    textArea.append("done...\n");
                     textArea.setCaretPosition(textArea.getText().length());
                 } catch (IOException e1) {
-                    JOptionPane.showMessageDialog(getFrame(), "异常：" + e1.getMessage(), "异常",JOptionPane.ERROR_MESSAGE);
-                    textArea.append("转换异常..." + "\n");
+                    JOptionPane.showMessageDialog(getFrame(), "Error: " + e1.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                    textArea.append("convert failed\n");
                     textArea.setCaretPosition(textArea.getText().length());
                 }
             }).start();
@@ -182,18 +188,18 @@ public class ZhConvertPanel extends EasyPanel {
             String key = keyText.getText();
             String value = valueText.getText();
 
-            if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)){
-                myZHConverterUtils.storeDataToProperties(key,value);
-                JOptionPane.showMessageDialog(ZhConvertPanel.this, "成功插入一条词组对应信息", "提示",JOptionPane.WARNING_MESSAGE);
+            if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)) {
+                myZHConverterUtils.storeDataToProperties(key, value);
+                JOptionPane.showMessageDialog(ZhConvertPanel.this, "Phrase rule added", "Info", JOptionPane.INFORMATION_MESSAGE);
                 refreshListData();
-                textArea.append("成功插入一条词组对应信息：" + key + " <===> " + value + "\n");
-            }else{
-                JOptionPane.showMessageDialog(ZhConvertPanel.this, "键值对不能为空", "提示",JOptionPane.WARNING_MESSAGE);
+                textArea.append("Added phrase rule: " + key + " <===> " + value + "\n");
+            } else {
+                JOptionPane.showMessageDialog(ZhConvertPanel.this, "Key and value must not be empty", "Error", JOptionPane.WARNING_MESSAGE);
             }
         }
     }
 
-    private void refreshListData(){
+    private void refreshListData() {
         List<String> listModel = new ArrayList<>();
         Properties properties = myZHConverterUtils.getCharMap();
         for (String key2 : properties.stringPropertyNames()) {
@@ -203,24 +209,24 @@ public class ZhConvertPanel extends EasyPanel {
     }
 
     private static void scanFolderAndConver(List<File> fileList, String converType, JTextArea jTextArea) throws IOException {
-        jTextArea.append("文件转换开始：\n");
-        for (File file : fileList){
-            jTextArea.append("开始转换："+file + "\n");
+        jTextArea.append("Start converting files:\n");
+        for (File file : fileList) {
+            jTextArea.append("Converting: " + file + "\n");
             String content = org.apache.commons.io.FileUtils.readFileToString(file, "utf-8");
 
-            if (converType.equals(Constants.zhSimple2zhTw)){
+            if (converType.equals(Constants.zhSimple2zhTw)) {
                 String str = myZHConverterUtils.myConvertToTW(content);
                 String result = ZhConverterUtil.toTraditional(str);
-                org.apache.commons.io.FileUtils.write(file,result,"UTF-8");
-            }else{
+                org.apache.commons.io.FileUtils.write(file, result, "UTF-8");
+            } else {
                 String str = myZHConverterUtils.myConvertToSimple(content);
                 String result = ZhConverterUtil.toSimple(str);
-                org.apache.commons.io.FileUtils.write(file,result,"UTF-8");
+                org.apache.commons.io.FileUtils.write(file, result, "UTF-8");
             }
-            jTextArea.append("转换完成："+file + "\n");
+            jTextArea.append("Done: " + file + "\n");
             jTextArea.setCaretPosition(jTextArea.getText().length());
         }
-        jTextArea.append("文件转换结束：\n");
-        jTextArea.append("==========================================================================：\n");
+        jTextArea.append("All conversions finished.\n");
+        jTextArea.append("==========================================================================\n");
     }
 }

--- a/src/main/java/edu/jiangxin/apktoolbox/help/AboutPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/help/AboutPanel.java
@@ -16,6 +16,7 @@ import javax.swing.border.EmptyBorder;
 
 import edu.jiangxin.apktoolbox.Version;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 
 /**
  * @author jiangxin
@@ -28,9 +29,10 @@ public class AboutPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        setBorder(new EmptyBorder(10, 10, 10, 10));
+        setBorder(new EmptyBorder(UiKit.PAD, UiKit.PAD, UiKit.PAD, UiKit.PAD));
         BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
         setLayout(boxLayout);
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         InputStream inputStream = null;
         BufferedReader bufferedReader = null;
@@ -69,7 +71,7 @@ public class AboutPanel extends EasyPanel {
         editorPane.setEditable(false);
 
         JScrollPane scrollPane = new JScrollPane(editorPane);
-        scrollPane.setPreferredSize(new Dimension(800, 300));
+        scrollPane.setPreferredSize(new Dimension(820, 320));
 
         add(scrollPane);
     }

--- a/src/main/java/edu/jiangxin/apktoolbox/help/settings/DependencyPathPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/help/settings/DependencyPathPanel.java
@@ -21,22 +21,26 @@ public class DependencyPathPanel extends EasyChildTabbedPanel {
         setAlignmentX(Component.LEFT_ALIGNMENT);
         setBorder(UiKit.sectionBorder("Third-party Dependencies"));
 
-        createPathPanel(this, "7-Zip (e.g. C:/Program Files/7-Zip/7z.exe)", "https://www.7-zip.org/", Constants.SEVEN_ZIP_PATH_KEY);
+        createPathPanel(this, "7-Zip", "https://www.7-zip.org/", Constants.SEVEN_ZIP_PATH_KEY);
         add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        createPathPanel(this, "RAR (e.g. C:/Program Files/WinRAR/Rar.exe)", "https://www.win-rar.com/", Constants.RAR_PATH_KEY);
+        createPathPanel(this, "RAR", "https://www.win-rar.com/", Constants.RAR_PATH_KEY);
         add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        createPathPanel(this, "WinRAR (e.g. C:/Program Files/WinRAR/WinRAR.exe)", "https://www.win-rar.com/", Constants.WIN_RAR_PATH_KEY);
+        createPathPanel(this, "WinRAR", "https://www.win-rar.com/", Constants.WIN_RAR_PATH_KEY);
     }
 
-    private void createPathPanel(JPanel panel, String label, String website, String confKey) {
+    private void createPathPanel(JPanel panel, String name, String website, String confKey) {
         JPanel pathPanel = new JPanel();
         pathPanel.setLayout(new BoxLayout(pathPanel, BoxLayout.Y_AXIS));
         pathPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         panel.add(pathPanel);
 
+        JLabel nameLabel = new JLabel(name);
+        nameLabel.setPreferredSize(new Dimension(UiKit.LABEL_WIDTH, UiKit.FIELD_HEIGHT));
+
         JButton visitWebsiteButton = UiKit.secondaryButton(bundle.getString("download.button"));
+        visitWebsiteButton.setToolTipText(website);
         visitWebsiteButton.addActionListener(e -> {
             URI uri;
             try {
@@ -49,8 +53,17 @@ public class DependencyPathPanel extends EasyChildTabbedPanel {
             }
         });
 
+        JPanel header = new JPanel(new BorderLayout(UiKit.GAP_SM, 0));
+        header.setOpaque(false);
+        header.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT));
+        header.add(nameLabel, BorderLayout.WEST);
+        header.add(visitWebsiteButton, BorderLayout.EAST);
+        pathPanel.add(header);
+        pathPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+
         JTextField pathTextField = UiKit.field(new JTextField());
         pathTextField.setText(conf.getString(confKey));
+        pathTextField.setToolTipText("Executable path, e.g. C:/Program Files/" + name + "/");
 
         JButton pathButton = UiKit.secondaryButton(bundle.getString("choose.file.button"));
         pathButton.addActionListener(e -> {
@@ -65,8 +78,6 @@ public class DependencyPathPanel extends EasyChildTabbedPanel {
             }
         });
 
-        pathPanel.add(UiKit.formRow(label, visitWebsiteButton));
-        pathPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         pathPanel.add(UiKit.formRow("Path", pathTextField, pathButton));
     }
 }

--- a/src/main/java/edu/jiangxin/apktoolbox/help/settings/DependencyPathPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/help/settings/DependencyPathPanel.java
@@ -1,6 +1,7 @@
 package edu.jiangxin.apktoolbox.help.settings;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyChildTabbedPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 
 import javax.swing.*;
@@ -16,52 +17,26 @@ public class DependencyPathPanel extends EasyChildTabbedPanel {
 
     @Override
     public void createUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Third-party Dependencies"));
 
-        createPathPanel(this, "Path of 7ZIP(e.g.\"C:/Program Files/7-Zip/7z.exe\")", "https://www.7-zip.org/", Constants.SEVEN_ZIP_PATH_KEY);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        createPathPanel(this, "7-Zip (e.g. C:/Program Files/7-Zip/7z.exe)", "https://www.7-zip.org/", Constants.SEVEN_ZIP_PATH_KEY);
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        createPathPanel(this, "Path of RAR(e.g.\"C:/Program Files/WinRAR/Rar.exe\")", "https://www.win-rar.com/", Constants.RAR_PATH_KEY);
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        createPathPanel(this, "RAR (e.g. C:/Program Files/WinRAR/Rar.exe)", "https://www.win-rar.com/", Constants.RAR_PATH_KEY);
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
-        createPathPanel(this, "Path of RAR(e.g.\"C:/Program Files/WinRAR/WinRAR.exe\")", "https://www.win-rar.com/", Constants.WIN_RAR_PATH_KEY);
+        createPathPanel(this, "WinRAR (e.g. C:/Program Files/WinRAR/WinRAR.exe)", "https://www.win-rar.com/", Constants.WIN_RAR_PATH_KEY);
     }
 
     private void createPathPanel(JPanel panel, String label, String website, String confKey) {
         JPanel pathPanel = new JPanel();
         pathPanel.setLayout(new BoxLayout(pathPanel, BoxLayout.Y_AXIS));
+        pathPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         panel.add(pathPanel);
 
-        JPanel firstLinePanel = new JPanel();
-        firstLinePanel.setLayout(new BoxLayout(firstLinePanel, BoxLayout.X_AXIS));
-
-        JLabel pathLabel = new JLabel(label);
-
-        JButton visitWebsiteButton = new JButton(bundle.getString("download.button"));
-
-        firstLinePanel.add(pathLabel);
-        firstLinePanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        firstLinePanel.add(visitWebsiteButton);
-        firstLinePanel.add(Box.createHorizontalGlue());
-
-        JPanel secondLinePanel = new JPanel();
-        secondLinePanel.setLayout(new BoxLayout(secondLinePanel, BoxLayout.X_AXIS));
-
-        JTextField pathTextField = new JTextField();
-        pathTextField.setText(conf.getString(confKey));
-
-        JButton pathButton = new JButton(bundle.getString("choose.file.button"));
-
-        secondLinePanel.add(pathTextField);
-        secondLinePanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        secondLinePanel.add(pathButton);
-
-        pathPanel.add(firstLinePanel);
-        pathPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        pathPanel.add(secondLinePanel);
-
-
+        JButton visitWebsiteButton = UiKit.secondaryButton(bundle.getString("download.button"));
         visitWebsiteButton.addActionListener(e -> {
             URI uri;
             try {
@@ -74,6 +49,10 @@ public class DependencyPathPanel extends EasyChildTabbedPanel {
             }
         });
 
+        JTextField pathTextField = UiKit.field(new JTextField());
+        pathTextField.setText(conf.getString(confKey));
+
+        JButton pathButton = UiKit.secondaryButton(bundle.getString("choose.file.button"));
         pathButton.addActionListener(e -> {
             JFileChooser jfc = new JFileChooser();
             jfc.setFileSelectionMode(JFileChooser.FILES_ONLY);
@@ -85,6 +64,10 @@ public class DependencyPathPanel extends EasyChildTabbedPanel {
                 conf.setProperty(confKey, pathTextField.getText());
             }
         });
+
+        pathPanel.add(UiKit.formRow(label, visitWebsiteButton));
+        pathPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        pathPanel.add(UiKit.formRow("Path", pathTextField, pathButton));
     }
 }
 

--- a/src/main/java/edu/jiangxin/apktoolbox/help/settings/LocalePanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/help/settings/LocalePanel.java
@@ -1,7 +1,7 @@
 package edu.jiangxin.apktoolbox.help.settings;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyChildTabbedPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
@@ -26,27 +26,22 @@ public class LocalePanel extends EasyChildTabbedPanel {
 
     @Override
     public void createUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Display Language"));
 
         createOptionPanel();
         add(optionPanel);
-
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
         add(operationPanel);
-
-        add(Box.createVerticalStrut(15 * Constants.DEFAULT_Y_BORDER));
     }
 
     private void createOptionPanel() {
-        optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
-
-        JLabel typeLabel = new JLabel("Locale:");
         typeComboBox = new JComboBox<>();
-        typeComboBox.setMaximumSize(new Dimension(Constants.DEFAULT_COMBOBOX_WIDTH, Constants.DEFAULT_COMBOBOX_HEIGHT));
+        typeComboBox.setPreferredSize(new Dimension(200, UiKit.FIELD_HEIGHT));
+        typeComboBox.setMaximumSize(new Dimension(200, UiKit.FIELD_HEIGHT));
 
         String currentLocaleLanguage = conf.getString("locale.language");
         if (StringUtils.isEmpty(currentLocaleLanguage)) {
@@ -61,19 +56,13 @@ public class LocalePanel extends EasyChildTabbedPanel {
             }
         }
 
-        optionPanel.add(typeLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        optionPanel.add(typeComboBox);
+        optionPanel = UiKit.formRow("Locale", typeComboBox);
     }
 
     private void createOperationPanel() {
-        operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-
-        JButton applyButton = new JButton("Apply");
+        JButton applyButton = UiKit.primaryButton("Apply");
         applyButton.addActionListener(new ApplyButtonActionListener());
-
-        operationPanel.add(applyButton);
+        operationPanel = UiKit.actionRow(applyButton);
     }
 
     private final class ApplyButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/help/settings/LookAndFeelPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/help/settings/LookAndFeelPanel.java
@@ -1,7 +1,7 @@
 package edu.jiangxin.apktoolbox.help.settings;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyChildTabbedPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Strings;
 
@@ -31,27 +31,22 @@ public class LookAndFeelPanel extends EasyChildTabbedPanel {
 
     @Override
     public void createUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("Look and Feel"));
 
         createOptionPanel();
         add(optionPanel);
-
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
         add(operationPanel);
-
-        add(Box.createVerticalStrut(15 * Constants.DEFAULT_Y_BORDER));
     }
 
     private void createOptionPanel() {
-        optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
-
-        JLabel typeLabel = new JLabel("Type:");
         typeComboBox = new JComboBox<>();
-        typeComboBox.setMaximumSize(new Dimension(Constants.DEFAULT_COMBOBOX_WIDTH, Constants.DEFAULT_COMBOBOX_HEIGHT));
+        typeComboBox.setPreferredSize(new Dimension(260, UiKit.FIELD_HEIGHT));
+        typeComboBox.setMaximumSize(new Dimension(260, UiKit.FIELD_HEIGHT));
 
         UIManager.LookAndFeelInfo[] lookAndFeelInfos = UIManager.getInstalledLookAndFeels();
         if (ArrayUtils.isEmpty(lookAndFeelInfos)) {
@@ -67,19 +62,13 @@ public class LookAndFeelPanel extends EasyChildTabbedPanel {
             }
         }
 
-        optionPanel.add(typeLabel);
-        optionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        optionPanel.add(typeComboBox);
+        optionPanel = UiKit.formRow("Type", typeComboBox);
     }
 
     private void createOperationPanel() {
-        operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-
-        JButton applyButton = new JButton("Apply");
+        JButton applyButton = UiKit.primaryButton("Apply");
         applyButton.addActionListener(new ApplyButtonActionListener());
-
-        operationPanel.add(applyButton);
+        operationPanel = UiKit.actionRow(applyButton);
     }
 
     private final class ApplyButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/main/MainFrame.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/main/MainFrame.java
@@ -26,6 +26,7 @@ import edu.jiangxin.apktoolbox.android.screenshot.ScreenShotPanel;
 import edu.jiangxin.apktoolbox.reverse.ApktoolPanel;
 import edu.jiangxin.apktoolbox.swing.extend.EasyFrame;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.swing.extend.listener.ChangeMenuListener;
 import edu.jiangxin.apktoolbox.swing.extend.listener.ChangeMenuToUrlListener;
 import edu.jiangxin.apktoolbox.swing.extend.listener.IPreChangeMenuCallBack;
@@ -80,6 +81,7 @@ public final class MainFrame extends EasyFrame {
             } catch (UnsupportedLookAndFeelException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
                 logger.error("setLookAndFeel failed, use default instead", e);
             }
+            UiKit.applyGlobalDefaults();
 
             String currentLocaleLanguage = conf.getString("locale.language");
             if (StringUtils.isEmpty(currentLocaleLanguage)) {
@@ -109,12 +111,12 @@ public final class MainFrame extends EasyFrame {
         setDefaultCloseOperation(EXIT_ON_CLOSE);
         setMenuBar();
         contentPane = new JPanel();
-        contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
+        contentPane.setBorder(new EmptyBorder(UiKit.PAD, UiKit.PAD, UiKit.PAD, UiKit.PAD));
         contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
         contentPane.add(Box.createVerticalGlue());
         EasyPanel initPanel = new AboutPanel();
         initPanel.init();
-        initPanel.setBorder(BorderFactory.createTitledBorder(bundle.getString("help.about.title")));
+        initPanel.setBorder(UiKit.sectionBorder(bundle.getString("help.about.title")));
         contentPane.add(initPanel);
         contentPane.add(Box.createVerticalGlue());
         setContentPane(contentPane);
@@ -385,7 +387,7 @@ public final class MainFrame extends EasyFrame {
             contentPane.removeAll();
             contentPane.add(Box.createVerticalGlue());
             panel.init();
-            panel.setBorder(BorderFactory.createTitledBorder(title));
+            panel.setBorder(UiKit.sectionBorder(title));
             contentPane.add(panel);
             logger.info("Panel changed: " + panel.getClass().getSimpleName());
             contentPane.add(Box.createVerticalGlue());

--- a/src/main/java/edu/jiangxin/apktoolbox/pdf/finder/PdfFinderPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/pdf/finder/PdfFinderPanel.java
@@ -3,13 +3,14 @@ package edu.jiangxin.apktoolbox.pdf.finder;
 import edu.jiangxin.apktoolbox.pdf.PdfUtils;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.DateUtils;
 import edu.jiangxin.apktoolbox.utils.ExcelExporter;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import edu.jiangxin.apktoolbox.utils.RevealFileUtils;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.*;
@@ -71,7 +72,7 @@ public class PdfFinderPanel extends EasyPanel {
         add(tabbedPane);
 
         createMainPanel();
-        tabbedPane.addTab("Option", null, mainPanel, "Show Search Options");
+        tabbedPane.addTab("Options", null, mainPanel, "Show Search Options");
 
         createResultPanel();
         tabbedPane.addTab("Result", null, resultPanel, "Show Search Result");
@@ -80,100 +81,86 @@ public class PdfFinderPanel extends EasyPanel {
     private void createMainPanel() {
         mainPanel = new JPanel();
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        mainPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         fileListPanel = new FileListPanel();
         fileListPanel.initialize();
 
-        JPanel checkOptionPanel = new JPanel();
-        checkOptionPanel.setLayout(new BoxLayout(checkOptionPanel, BoxLayout.X_AXIS));
-        checkOptionPanel.setBorder(BorderFactory.createTitledBorder("Check Options"));
-
         ButtonGroup buttonGroup = new ButtonGroup();
         ItemListener itemListener = new RadioButtonItemListener();
 
-        scannedRadioButton = new JRadioButton("查找扫描的PDF文件");
+        scannedRadioButton = new JRadioButton("Scanned PDF files");
         scannedRadioButton.setSelected(true);
         scannedRadioButton.addItemListener(itemListener);
         buttonGroup.add(scannedRadioButton);
 
-        encryptedRadioButton = new JRadioButton("查找加密的PDF文件");
+        encryptedRadioButton = new JRadioButton("Encrypted PDF files");
         encryptedRadioButton.addItemListener(itemListener);
         buttonGroup.add(encryptedRadioButton);
 
-        nonOutlineRadioButton = new JRadioButton("查找没有目录的PDF文件");
+        nonOutlineRadioButton = new JRadioButton("PDF files without outline");
         nonOutlineRadioButton.addItemListener(itemListener);
         buttonGroup.add(nonOutlineRadioButton);
 
-        hasAnnotationsRadioButton = new JRadioButton("查找有注释的PDF文件");
+        hasAnnotationsRadioButton = new JRadioButton("PDF files with annotations");
         hasAnnotationsRadioButton.addItemListener(itemListener);
         buttonGroup.add(hasAnnotationsRadioButton);
 
-        JPanel typePanel = new JPanel();
-        typePanel.setLayout(new FlowLayout(FlowLayout.LEFT,10,3));
-        typePanel.add(scannedRadioButton);
-        typePanel.add(encryptedRadioButton);
-        typePanel.add(nonOutlineRadioButton);
-        typePanel.add(hasAnnotationsRadioButton);
-
-        JLabel thresholdLabel = new JLabel("Threshold: ");
         thresholdSpinner = new JSpinner();
         thresholdSpinner.setModel(new SpinnerNumberModel(1, 0, 100, 1));
+        thresholdSpinner.setPreferredSize(new Dimension(80, UiKit.FIELD_HEIGHT));
+        thresholdSpinner.setMaximumSize(new Dimension(80, UiKit.FIELD_HEIGHT));
 
-        checkOptionPanel.add(typePanel);
-        checkOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        checkOptionPanel.add(thresholdLabel);
-        checkOptionPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        checkOptionPanel.add(thresholdSpinner);
-        checkOptionPanel.add(Box.createHorizontalGlue());
-
-        JPanel searchOptionPanel = new JPanel();
-        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.X_AXIS));
-        searchOptionPanel.setBorder(BorderFactory.createTitledBorder("Search Options"));
+        JPanel checkOptionPanel = new JPanel();
+        checkOptionPanel.setLayout(new BoxLayout(checkOptionPanel, BoxLayout.Y_AXIS));
+        checkOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        checkOptionPanel.setBorder(UiKit.sectionBorder("Check Options"));
+        checkOptionPanel.add(UiKit.checkRow(scannedRadioButton, encryptedRadioButton, nonOutlineRadioButton, hasAnnotationsRadioButton));
+        checkOptionPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
+        checkOptionPanel.add(UiKit.formRow("Threshold", thresholdSpinner));
 
         isRecursiveSearched = new JCheckBox("Recursive");
         isRecursiveSearched.setSelected(true);
-        searchOptionPanel.add(isRecursiveSearched);
-        searchOptionPanel.add(Box.createHorizontalGlue());
 
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.setBorder(BorderFactory.createTitledBorder("Operations"));
+        JPanel searchOptionPanel = new JPanel();
+        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.Y_AXIS));
+        searchOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        searchOptionPanel.setBorder(UiKit.sectionBorder("Search Options"));
+        searchOptionPanel.add(UiKit.checkRow(isRecursiveSearched));
 
-        JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
-
-        searchButton = new JButton("Search");
-        cancelButton = new JButton("Cancel");
+        searchButton = UiKit.primaryButton("Search");
+        cancelButton = UiKit.secondaryButton("Cancel");
         cancelButton.setEnabled(false);
         searchButton.addActionListener(new OperationButtonActionListener());
         cancelButton.addActionListener(new OperationButtonActionListener());
-        operationPanel.add(searchButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(cancelButton);
-        operationPanel.add(Box.createHorizontalGlue());
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setString("Ready");
+        progressBar.setPreferredSize(new Dimension(0, 22));
+        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
         mainPanel.add(fileListPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         mainPanel.add(checkOptionPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         mainPanel.add(searchOptionPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        mainPanel.add(operationPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
+        mainPanel.add(UiKit.actionRow(cancelButton, searchButton));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         mainPanel.add(progressBar);
     }
 
     private void createResultPanel() {
         resultPanel = new JPanel();
-        resultPanel.setLayout(new BoxLayout(resultPanel, BoxLayout.Y_AXIS));
+        resultPanel.setLayout(new BorderLayout());
+        resultPanel.setBorder(new EmptyBorder(UiKit.GAP_XS, 0, 0, 0));
 
         resultTableModel = new PdfFilesTableModel(new Vector<>(), PdfFilesConstants.COLUMN_NAMES);
         resultTable = new JTable(resultTableModel);
+        resultTable.setRowHeight(28);
+        resultTable.setShowGrid(false);
+        resultTable.setIntercellSpacing(new Dimension(0, 0));
 
         resultTable.setDefaultRenderer(Vector.class, new PdfFilesTableCellRenderer());
 
@@ -186,7 +173,7 @@ public class PdfFinderPanel extends EasyPanel {
         resultTable.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
 
         JScrollPane scrollPane = new JScrollPane(resultTable);
-        resultPanel.add(scrollPane);
+        resultPanel.add(scrollPane, BorderLayout.CENTER);
     }
 
     private void processFile(File file) {

--- a/src/main/java/edu/jiangxin/apktoolbox/pdf/passwordremover/PdfPasswordRemoverPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/pdf/passwordremover/PdfPasswordRemoverPanel.java
@@ -4,10 +4,11 @@ import edu.jiangxin.apktoolbox.pdf.PdfUtils;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
 import edu.jiangxin.apktoolbox.swing.extend.filepanel.FilePanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -40,20 +41,20 @@ public class PdfPasswordRemoverPanel extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createInputPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOutputPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOptionPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_SM));
 
         createProcessBarPanel();
     }
@@ -65,48 +66,46 @@ public class PdfPasswordRemoverPanel extends EasyPanel {
     }
 
     private void createOutputPanel() {
+        JPanel outputPanel = new JPanel();
+        outputPanel.setLayout(new BoxLayout(outputPanel, BoxLayout.Y_AXIS));
+        outputPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        outputPanel.setBorder(UiKit.sectionBorder("Output"));
+
         targetDirPanel = new FilePanel("Target Directory");
         targetDirPanel.initialize();
         targetDirPanel.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        add(targetDirPanel);
+        outputPanel.add(UiKit.formRow("Target", targetDirPanel));
+        add(outputPanel);
     }
 
     private void createOptionPanel() {
         JPanel optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
-        optionPanel.setBorder(BorderFactory.createTitledBorder("Options"));
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Options"));
 
         isRecursiveSearched = new JCheckBox("Recursive Search");
         isRecursiveSearched.setSelected(true);
-        optionPanel.add(isRecursiveSearched);
-        optionPanel.add(Box.createHorizontalGlue());
+        optionPanel.add(UiKit.checkRow(isRecursiveSearched));
 
         add(optionPanel);
     }
 
     private void createOperationPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.setBorder(BorderFactory.createTitledBorder("Operations"));
-
-        startButton = new JButton("Start");
-        cancelButton = new JButton("Cancel");
+        startButton = UiKit.primaryButton("Start");
+        cancelButton = UiKit.secondaryButton("Cancel");
         cancelButton.setEnabled(false);
         startButton.addActionListener(new OperationButtonActionListener());
         cancelButton.addActionListener(new OperationButtonActionListener());
-        operationPanel.add(startButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(cancelButton);
-        operationPanel.add(Box.createHorizontalGlue());
-
-        add(operationPanel);
+        add(UiKit.actionRow(cancelButton, startButton));
     }
 
     private void createProcessBarPanel() {
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setString("Ready");
+        progressBar.setPreferredSize(new Dimension(0, 22));
+        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
         add(progressBar);
     }

--- a/src/main/java/edu/jiangxin/apktoolbox/pdf/pic2pdf/Pic2PdfPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/pdf/pic2pdf/Pic2PdfPanel.java
@@ -4,10 +4,11 @@ import edu.jiangxin.apktoolbox.pdf.PdfUtils;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
 import edu.jiangxin.apktoolbox.swing.extend.filepanel.FilePanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -35,17 +36,17 @@ public class Pic2PdfPanel  extends EasyPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createInputPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOutputPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOptionPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
     }
@@ -57,42 +58,38 @@ public class Pic2PdfPanel  extends EasyPanel {
     }
 
     private void createOutputPanel() {
+        JPanel outputPanel = new JPanel();
+        outputPanel.setLayout(new BoxLayout(outputPanel, BoxLayout.Y_AXIS));
+        outputPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        outputPanel.setBorder(UiKit.sectionBorder("Output"));
+
         targetDirPanel = new FilePanel("Target Directory");
         targetDirPanel.initialize();
         targetDirPanel.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        add(targetDirPanel);
+        outputPanel.add(UiKit.formRow("Target", targetDirPanel));
+        add(outputPanel);
     }
 
     private void createOptionPanel() {
         JPanel optionPanel = new JPanel();
-        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.X_AXIS));
-        optionPanel.setBorder(BorderFactory.createTitledBorder("Options"));
+        optionPanel.setLayout(new BoxLayout(optionPanel, BoxLayout.Y_AXIS));
+        optionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        optionPanel.setBorder(UiKit.sectionBorder("Options"));
 
         isRecursiveSearched = new JCheckBox("Recursive Search");
         isRecursiveSearched.setSelected(true);
-        optionPanel.add(isRecursiveSearched);
-        optionPanel.add(Box.createHorizontalGlue());
+        optionPanel.add(UiKit.checkRow(isRecursiveSearched));
 
         add(optionPanel);
     }
 
     private void createOperationPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.setBorder(BorderFactory.createTitledBorder("Operations"));
-
-        startButton = new JButton("Start");
-        cancelButton = new JButton("Cancel");
+        startButton = UiKit.primaryButton("Start");
+        cancelButton = UiKit.secondaryButton("Cancel");
         cancelButton.setEnabled(false);
         startButton.addActionListener(new OperationButtonActionListener());
         cancelButton.addActionListener(new OperationButtonActionListener());
-        operationPanel.add(startButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(cancelButton);
-        operationPanel.add(Box.createHorizontalGlue());
-
-        add(operationPanel);
+        add(UiKit.actionRow(cancelButton, startButton));
     }
 
     private void processFile(File encryptedFile, File targetDir) {

--- a/src/main/java/edu/jiangxin/apktoolbox/pdf/stat/PdfStatPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/pdf/stat/PdfStatPanel.java
@@ -3,12 +3,13 @@ package edu.jiangxin.apktoolbox.pdf.stat;
 import edu.jiangxin.apktoolbox.pdf.PdfUtils;
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.DateUtils;
 import edu.jiangxin.apktoolbox.utils.ExcelExporter;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -69,7 +70,7 @@ public class PdfStatPanel extends EasyPanel {
         add(tabbedPane);
 
         createMainPanel();
-        tabbedPane.addTab("Option", null, mainPanel, "Show Stat Options");
+        tabbedPane.addTab("Options", null, mainPanel, "Show Stat Options");
 
         createResultPanel();
         tabbedPane.addTab("Result", null, resultPanel, "Show Stat Result");
@@ -78,76 +79,66 @@ public class PdfStatPanel extends EasyPanel {
     private void createMainPanel() {
         mainPanel = new JPanel();
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        mainPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         fileListPanel = new FileListPanel();
         fileListPanel.initialize();
 
-        JPanel checkOptionPanel = new JPanel();
-        checkOptionPanel.setLayout(new BoxLayout(checkOptionPanel, BoxLayout.X_AXIS));
-        checkOptionPanel.setBorder(BorderFactory.createTitledBorder("Check Options"));
-
         ButtonGroup buttonGroup = new ButtonGroup();
 
-        pageCountRadioButton = new JRadioButton("统计页数");
+        pageCountRadioButton = new JRadioButton("Count pages");
         pageCountRadioButton.setSelected(true);
         pageCountRadioButton.setEnabled(false);
         buttonGroup.add(pageCountRadioButton);
 
-        JPanel typePanel = new JPanel();
-        typePanel.setLayout(new FlowLayout(FlowLayout.LEFT,10,3));
-        typePanel.add(pageCountRadioButton);
-
-        checkOptionPanel.add(typePanel);
-        checkOptionPanel.add(Box.createHorizontalGlue());
-
-        JPanel searchOptionPanel = new JPanel();
-        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.X_AXIS));
-        searchOptionPanel.setBorder(BorderFactory.createTitledBorder("Stat Options"));
+        JPanel checkOptionPanel = new JPanel();
+        checkOptionPanel.setLayout(new BoxLayout(checkOptionPanel, BoxLayout.Y_AXIS));
+        checkOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        checkOptionPanel.setBorder(UiKit.sectionBorder("Check Options"));
+        checkOptionPanel.add(UiKit.checkRow(pageCountRadioButton));
 
         isRecursiveSearched = new JCheckBox("Recursive");
         isRecursiveSearched.setSelected(true);
-        searchOptionPanel.add(isRecursiveSearched);
-        searchOptionPanel.add(Box.createHorizontalGlue());
 
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.setBorder(BorderFactory.createTitledBorder("Operations"));
+        JPanel searchOptionPanel = new JPanel();
+        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.Y_AXIS));
+        searchOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        searchOptionPanel.setBorder(UiKit.sectionBorder("Stat Options"));
+        searchOptionPanel.add(UiKit.checkRow(isRecursiveSearched));
 
-        JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
-
-        statButton = new JButton("Stat");
-        cancelButton = new JButton("Cancel");
+        statButton = UiKit.primaryButton("Stat");
+        cancelButton = UiKit.secondaryButton("Cancel");
         cancelButton.setEnabled(false);
         statButton.addActionListener(new OperationButtonActionListener());
         cancelButton.addActionListener(new OperationButtonActionListener());
-        operationPanel.add(statButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(cancelButton);
-        operationPanel.add(Box.createHorizontalGlue());
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setString("Ready");
+        progressBar.setPreferredSize(new Dimension(0, 22));
+        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
         mainPanel.add(fileListPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         mainPanel.add(checkOptionPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         mainPanel.add(searchOptionPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        mainPanel.add(operationPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
+        mainPanel.add(UiKit.actionRow(cancelButton, statButton));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         mainPanel.add(progressBar);
     }
 
     private void createResultPanel() {
         resultPanel = new JPanel();
-        resultPanel.setLayout(new BoxLayout(resultPanel, BoxLayout.Y_AXIS));
+        resultPanel.setLayout(new BorderLayout());
+        resultPanel.setBorder(new EmptyBorder(UiKit.GAP_XS, 0, 0, 0));
 
         resultTableModel = new PdfFilesTableModel(new Vector<>(), PdfFilesConstants.COLUMN_NAMES);
         resultTable = new JTable(resultTableModel);
+        resultTable.setRowHeight(28);
+        resultTable.setShowGrid(false);
+        resultTable.setIntercellSpacing(new Dimension(0, 0));
         resultTable.setDefaultRenderer(Vector.class, new PdfFilesTableCellRenderer());
         for (int i = 0; i < resultTable.getColumnCount(); i++) {
             resultTable.getColumn(resultTable.getColumnName(i)).setCellRenderer(new PdfFilesTableCellRenderer());
@@ -158,7 +149,7 @@ public class PdfStatPanel extends EasyPanel {
             public void mouseReleased(MouseEvent e) {
                 if (e.isPopupTrigger() && e.getComponent() instanceof JTable) {
                     JPopupMenu popupmenu = new JPopupMenu();
-                    JMenuItem exportMenuItem = new JMenuItem("导出到 Excel");
+                    JMenuItem exportMenuItem = new JMenuItem("Export to Excel");
                     exportMenuItem.addActionListener(ev ->
                         ExcelExporter.export(resultTableModel, "pdf_stat_export.xlsx", PdfStatPanel.this));
                     popupmenu.add(exportMenuItem);
@@ -174,9 +165,8 @@ public class PdfStatPanel extends EasyPanel {
         statInfoPanel.add(statInfoLabel);
         statInfoPanel.add(Box.createHorizontalGlue());
 
-        resultPanel.add(scrollPane);
-        resultPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        resultPanel.add(statInfoPanel);
+        resultPanel.add(scrollPane, BorderLayout.CENTER);
+        resultPanel.add(statInfoPanel, BorderLayout.SOUTH);
     }
 
     private void processFile(File file) {

--- a/src/main/java/edu/jiangxin/apktoolbox/reverse/ApkSignerPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/reverse/ApkSignerPanel.java
@@ -2,7 +2,7 @@ package edu.jiangxin.apktoolbox.reverse;
 
 import edu.jiangxin.apktoolbox.swing.extend.listener.SelectFileListener;
 import edu.jiangxin.apktoolbox.swing.extend.plugin.PluginPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Utils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -41,118 +41,78 @@ public class ApkSignerPanel extends PluginPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("APK Signing"));
 
         createApkPathPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createKeyStorePathPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createKeyStorePasswordPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createAliasPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createAliasPasswordPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOptionPanel();
     }
 
     private void createOptionPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        add(operationPanel);
-
-        JButton recoverButton = new JButton("recover");
+        JButton recoverButton = UiKit.secondaryButton("Recover Defaults");
         recoverButton.addActionListener(new RecoverButtonActionListener());
 
-        JButton apkSignButton = new JButton("apksigner");
+        JButton apkSignButton = UiKit.primaryButton("Sign APK");
         apkSignButton.addActionListener(new ApkSignButtonActionListener());
 
-        operationPanel.add(recoverButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(apkSignButton);
+        add(UiKit.actionRow(recoverButton, apkSignButton));
     }
 
     private void createAliasPasswordPanel() {
-        JPanel aliasPasswordPanel = new JPanel();
-        aliasPasswordPanel.setLayout(new BoxLayout(aliasPasswordPanel, BoxLayout.X_AXIS));
-        add(aliasPasswordPanel);
-        
         aliasPasswordField = new JPasswordField();
         aliasPasswordField.setText(conf.getString("apksigner.alias.password"));
-
-        JLabel aliasPasswordLable = new JLabel("Alias Password");
-
-        aliasPasswordPanel.add(aliasPasswordField);
-        aliasPasswordPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        aliasPasswordPanel.add(aliasPasswordLable);
+        aliasPasswordField.setPreferredSize(new Dimension(0, UiKit.FIELD_HEIGHT));
+        aliasPasswordField.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT));
+        add(UiKit.formRow("Alias Password", aliasPasswordField));
     }
 
     private void createAliasPanel() {
-        JPanel aliasPanel = new JPanel();
-        aliasPanel.setLayout(new BoxLayout(aliasPanel, BoxLayout.X_AXIS));
-        add(aliasPanel);
-        
-        aliasTextField = new JTextField();
+        aliasTextField = UiKit.field(new JTextField());
         aliasTextField.setText(conf.getString("apksigner.alias"));
-
-        JLabel aliasLable = new JLabel("Alias");
-
-        aliasPanel.add(aliasTextField);
-        aliasPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        aliasPanel.add(aliasLable);
+        add(UiKit.formRow("Alias", aliasTextField));
     }
 
     private void createKeyStorePasswordPanel() {
-        JPanel keyStorePasswordPanel = new JPanel();
-        keyStorePasswordPanel.setLayout(new BoxLayout(keyStorePasswordPanel, BoxLayout.X_AXIS));
-        add(keyStorePasswordPanel);
-        
         keyStorePasswordField = new JPasswordField();
         keyStorePasswordField.setText(conf.getString("apksigner.keystore.password"));
-
-        JLabel keyStorePasswordLable = new JLabel("KeyStore Password");
-
-        keyStorePasswordPanel.add(keyStorePasswordField);
-        keyStorePasswordPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        keyStorePasswordPanel.add(keyStorePasswordLable);
+        keyStorePasswordField.setPreferredSize(new Dimension(0, UiKit.FIELD_HEIGHT));
+        keyStorePasswordField.setMaximumSize(new Dimension(Integer.MAX_VALUE, UiKit.FIELD_HEIGHT));
+        add(UiKit.formRow("KeyStore Password", keyStorePasswordField));
     }
 
     private void createKeyStorePathPanel() {
-        JPanel keyStorePathPanel = new JPanel();
-        keyStorePathPanel.setLayout(new BoxLayout(keyStorePathPanel, BoxLayout.X_AXIS));
-        add(keyStorePathPanel);
-        
-        keyStorePathTextField = new JTextField();
+        keyStorePathTextField = UiKit.field(new JTextField());
         keyStorePathTextField.setText(conf.getString("apksigner.keystore.path"));
 
-        JButton keyStorePathButton = new JButton("Select KeyStore");
+        JButton keyStorePathButton = UiKit.secondaryButton("Browse...");
         keyStorePathButton.addActionListener(new SelectFileListener("select a keystore file", keyStorePathTextField));
 
-        keyStorePathPanel.add(keyStorePathTextField);
-        keyStorePathPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        keyStorePathPanel.add(keyStorePathButton);
+        add(UiKit.formRow("KeyStore", keyStorePathTextField, keyStorePathButton));
     }
 
     private void createApkPathPanel() {
-        JPanel apkPathPanel = new JPanel();
-        apkPathPanel.setLayout(new BoxLayout(apkPathPanel, BoxLayout.X_AXIS));
-        add(apkPathPanel);
-
-        apkPathTextField = new JTextField();
+        apkPathTextField = UiKit.field(new JTextField());
         apkPathTextField.setText(conf.getString("apksigner.apk.path"));
 
-        JButton apkPathButton = new JButton("Select APK");
+        JButton apkPathButton = UiKit.secondaryButton("Browse...");
         apkPathButton.addActionListener(new SelectFileListener("select a APK file", apkPathTextField));
 
-        apkPathPanel.add(apkPathTextField);
-        apkPathPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        apkPathPanel.add(apkPathButton);
+        add(UiKit.formRow("APK", apkPathTextField, apkPathButton));
     }
     
     private final class RecoverButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/reverse/AxmlPrinterPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/reverse/AxmlPrinterPanel.java
@@ -2,7 +2,7 @@ package edu.jiangxin.apktoolbox.reverse;
 
 import edu.jiangxin.apktoolbox.swing.extend.listener.SelectDirectoryListener;
 import edu.jiangxin.apktoolbox.swing.extend.plugin.PluginPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.ProcessLogOutputStream;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -42,59 +42,43 @@ public class AxmlPrinterPanel extends PluginPanel {
 
     @Override
     public void initUI() {
-        BoxLayout boxLayout = new BoxLayout(this, BoxLayout.Y_AXIS);
-        setLayout(boxLayout);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
+        setBorder(UiKit.sectionBorder("AndroidManifest.xml Decompiler"));
 
         createSrcPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createTargetPanel();
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        add(Box.createVerticalStrut(UiKit.GAP_MD));
 
         createOperationPanel();
     }
 
     private void createOperationPanel() {
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        add(operationPanel);
-
-        JButton getFileButton = new JButton("Get File");
+        JButton getFileButton = UiKit.primaryButton("Decompile");
         getFileButton.addActionListener(new GetFileButtonActionListener());
-
-        operationPanel.add(getFileButton);
+        add(UiKit.actionRow(getFileButton));
     }
 
     private void createTargetPanel() {
-        JPanel targetPanel = new JPanel();
-        targetPanel.setLayout(new BoxLayout(targetPanel, BoxLayout.X_AXIS));
-        add(targetPanel);
-
-        targetTextField = new JTextField();
+        targetTextField = UiKit.field(new JTextField());
         targetTextField.setText(conf.getString("axmlprinter.target.dir"));
 
-        JButton targetButton = new JButton("Save Dir");
+        JButton targetButton = UiKit.secondaryButton("Browse...");
         targetButton.addActionListener(new SelectDirectoryListener("Save To", targetTextField));
 
-        targetPanel.add(targetTextField);
-        targetPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        targetPanel.add(targetButton);
+        add(UiKit.formRow("Save Directory", targetTextField, targetButton));
     }
 
     private void createSrcPanel() {
-        JPanel srcPanel = new JPanel();
-        srcPanel.setLayout(new BoxLayout(srcPanel, BoxLayout.X_AXIS));
-        add(srcPanel);
-
-        srcTextField = new JTextField();
+        srcTextField = UiKit.field(new JTextField());
         srcTextField.setText(conf.getString("axmlprinter.src.file"));
 
-        JButton srcButton = new JButton("Source File");
+        JButton srcButton = UiKit.secondaryButton("Browse...");
         srcButton.addActionListener(new SrcButtonActionListener());
 
-        srcPanel.add(srcTextField);
-        srcPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        srcPanel.add(srcButton);
+        add(UiKit.formRow("Source File", srcTextField, srcButton));
     }
 
     private final class SrcButtonActionListener implements ActionListener {

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/EasyFrame.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/EasyFrame.java
@@ -61,7 +61,7 @@ public class EasyFrame extends JFrame {
     public void refreshSizeAndLocation() {
         // use pack to resize the child component
         pack();
-        setMinimumSize(new Dimension(800, 100));
+        setMinimumSize(new Dimension(880, 120));
         setResizable(false);
 
         // relocation this JFrame

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/EasyPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/EasyPanel.java
@@ -1,5 +1,6 @@
 package edu.jiangxin.apktoolbox.swing.extend;
 
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import edu.jiangxin.apktoolbox.utils.Utils;
@@ -31,6 +32,9 @@ public class EasyPanel extends JPanel {
         logger = LogManager.getLogger(this.getClass().getSimpleName());
         conf = Utils.getConfiguration();
         bundle = ResourceBundle.getBundle("apktoolbox");
+        // Consistent base padding so every tool panel starts from the same rhythm.
+        setBorder(BorderFactory.createEmptyBorder(UiKit.GAP_SM, UiKit.GAP_SM, UiKit.GAP_SM, UiKit.GAP_SM));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
         logger.info("Panel start: " + this.getClass().getSimpleName());
     }
 

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/FileListPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/FileListPanel.java
@@ -1,10 +1,12 @@
 package edu.jiangxin.apktoolbox.swing.extend;
 
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
@@ -53,11 +55,12 @@ public class FileListPanel extends JPanel {
 
     private void initUI() {
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         createLeftPanel();
         add(leftPanel);
 
-        add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
+        add(Box.createHorizontalStrut(UiKit.GAP_MD));
 
         createRightPanel();
         add(rightPanel);
@@ -67,55 +70,47 @@ public class FileListPanel extends JPanel {
         fileList = new JList<>();
         fileListModel = new DefaultListModel<>();
         fileList.setModel(fileListModel);
+        fileList.setFixedCellHeight(26);
 
         JScrollPane scrollPane = new JScrollPane(fileList);
         scrollPane.setPreferredSize(new Dimension(Constants.DEFAULT_SCROLL_PANEL_WIDTH, Constants.DEFAULT_SCROLL_PANEL_HEIGHT));
 
         leftPanel = new JPanel();
-        leftPanel.setBorder(BorderFactory.createTitledBorder("File List"));
-        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.Y_AXIS));
+        leftPanel.setBorder(UiKit.sectionBorder("File List"));
+        leftPanel.setLayout(new BorderLayout());
         leftPanel.setTransferHandler(new FileListTransferHandler());
-        leftPanel.add(scrollPane);
+        leftPanel.add(scrollPane, BorderLayout.CENTER);
+        leftPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
     }
 
     private void createRightPanel() {
         rightPanel = new JPanel();
-        rightPanel.setLayout(new BoxLayout(rightPanel, BoxLayout.Y_AXIS));
+        rightPanel.setLayout(new BorderLayout());
+        rightPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         JPanel rightContentPanel = new JPanel();
-        rightPanel.add(Box.createVerticalGlue());
-        rightPanel.add(rightContentPanel);
-        rightPanel.add(Box.createVerticalGlue());
+        rightContentPanel.setLayout(new GridLayout(6, 1, 0, UiKit.GAP_SM));
+        rightContentPanel.setBorder(new EmptyBorder(0, UiKit.GAP_SM, 0, 0));
+        rightContentPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        rightContentPanel.setLayout(new GridLayout(6, 1, 0, Constants.DEFAULT_Y_BORDER));
+        rightContentPanel.add(createSideButton("Add File", new AddFileButtonActionListener()));
+        rightContentPanel.add(createSideButton("Add Directory", new AddDirectoryButtonActionListener()));
+        rightContentPanel.add(createSideButton("Remove Selected", new RemoveSelectedButtonActionListener()));
+        rightContentPanel.add(createSideButton("Clear All", new ClearButtonActionListener()));
+        rightContentPanel.add(createSideButton("Select All", new SelectAllButtonActionListener()));
+        rightContentPanel.add(createSideButton("Inverse Selected", new InverseSelectedButtonActionListener()));
 
-        JButton addFileButton = new JButton("Add File");
-        addFileButton.addActionListener(new AddFileButtonActionListener());
-        rightContentPanel.add(addFileButton);
+        rightPanel.add(Box.createVerticalGlue(), BorderLayout.NORTH);
+        rightPanel.add(rightContentPanel, BorderLayout.CENTER);
+        rightPanel.add(Box.createVerticalGlue(), BorderLayout.SOUTH);
+        rightPanel.setPreferredSize(new Dimension(UiKit.BUTTON_WIDTH + UiKit.GAP_SM * 2, Constants.DEFAULT_SCROLL_PANEL_HEIGHT));
+        rightPanel.setMaximumSize(rightPanel.getPreferredSize());
+    }
 
-        JButton addDirectoryButton = new JButton("Add Directory");
-        addDirectoryButton.addActionListener(new AddDirectoryButtonActionListener());
-        rightContentPanel.add(addDirectoryButton);
-
-        JButton removeSelectedButton = new JButton("Remove Selected");
-        removeSelectedButton.addActionListener(new RemoveSelectedButtonActionListener());
-        rightContentPanel.add(removeSelectedButton);
-
-        JButton clearButton = new JButton("Clear All");
-        clearButton.addActionListener(new ClearButtonActionListener());
-        rightContentPanel.add(clearButton);
-
-        JButton selectAllButton = new JButton("Select All");
-        selectAllButton.addActionListener(new SelectAllButtonActionListener());
-        rightContentPanel.add(selectAllButton);
-
-        JButton inverseSelectedButton = new JButton("Inverse Selected");
-        inverseSelectedButton.addActionListener(new InverseSelectedButtonActionListener());
-        rightContentPanel.add(inverseSelectedButton);
-
-        for (Component component : rightContentPanel.getComponents()) {
-            component.setPreferredSize(new Dimension(Constants.DEFAULT_BUTTON_WIDTH, Constants.DEFAULT_BUTTON_HEIGHT));
-        }
+    private JButton createSideButton(String text, ActionListener listener) {
+        JButton button = UiKit.secondaryButton(text);
+        button.addActionListener(listener);
+        return button;
     }
 
     private final class FileListTransferHandler extends TransferHandler {

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/FileListPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/FileListPanel.java
@@ -94,17 +94,19 @@ public class FileListPanel extends JPanel {
         rightContentPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         rightContentPanel.add(createSideButton("Add File", new AddFileButtonActionListener()));
-        rightContentPanel.add(createSideButton("Add Directory", new AddDirectoryButtonActionListener()));
-        rightContentPanel.add(createSideButton("Remove Selected", new RemoveSelectedButtonActionListener()));
+        rightContentPanel.add(createSideButton("Add Dir", new AddDirectoryButtonActionListener()));
+        rightContentPanel.add(createSideButton("Remove", new RemoveSelectedButtonActionListener()));
         rightContentPanel.add(createSideButton("Clear All", new ClearButtonActionListener()));
         rightContentPanel.add(createSideButton("Select All", new SelectAllButtonActionListener()));
-        rightContentPanel.add(createSideButton("Inverse Selected", new InverseSelectedButtonActionListener()));
+        rightContentPanel.add(createSideButton("Invert", new InverseSelectedButtonActionListener()));
 
         rightPanel.add(Box.createVerticalGlue(), BorderLayout.NORTH);
         rightPanel.add(rightContentPanel, BorderLayout.CENTER);
         rightPanel.add(Box.createVerticalGlue(), BorderLayout.SOUTH);
-        rightPanel.setPreferredSize(new Dimension(UiKit.BUTTON_WIDTH + UiKit.GAP_SM * 2, Constants.DEFAULT_SCROLL_PANEL_HEIGHT));
-        rightPanel.setMaximumSize(rightPanel.getPreferredSize());
+        int sideW = UiKit.BUTTON_WIDTH + UiKit.GAP_SM;
+        rightPanel.setPreferredSize(new Dimension(sideW, Constants.DEFAULT_SCROLL_PANEL_HEIGHT));
+        rightPanel.setMaximumSize(new Dimension(sideW, Constants.DEFAULT_SCROLL_PANEL_HEIGHT));
+        rightPanel.setMinimumSize(new Dimension(sideW, 120));
     }
 
     private JButton createSideButton(String text, ActionListener listener) {

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/filepanel/FilePanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/filepanel/FilePanel.java
@@ -1,5 +1,6 @@
 package edu.jiangxin.apktoolbox.swing.extend.filepanel;
 
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.Constants;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -88,17 +89,19 @@ public class FilePanel extends JPanel {
 
     private void initUI() {
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        setAlignmentX(Component.LEFT_ALIGNMENT);
 
         fileTextField = new JTextField();
-        fileTextField.setPreferredSize(new Dimension(600, 30));
-        fileTextField.setMaximumSize(new Dimension(1200, 30));
+        fileTextField.setPreferredSize(new Dimension(600, UiKit.FIELD_HEIGHT));
+        fileTextField.setMaximumSize(new Dimension(1200, UiKit.FIELD_HEIGHT));
+        fileTextField.setMinimumSize(new Dimension(200, UiKit.FIELD_HEIGHT));
         fileTextField.setTransferHandler(new FileTransferHandler());
 
-        JButton chooseButton = new JButton(buttonText);
+        JButton chooseButton = UiKit.secondaryButton(buttonText);
         chooseButton.addActionListener(new OpenDictionaryFileActionListener());
 
         add(fileTextField);
-        add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
+        add(Box.createHorizontalStrut(UiKit.GAP_MD));
         add(chooseButton);
     }
 

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/plugin/ProgressBarDialog.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/plugin/ProgressBarDialog.java
@@ -1,6 +1,6 @@
 package edu.jiangxin.apktoolbox.swing.extend.plugin;
 
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 
 import javax.swing.*;
 import java.awt.*;
@@ -18,33 +18,21 @@ public class ProgressBarDialog extends JDialog {
     // in case of escape of "this"
     public void initialize(String title) {
         setTitle(title);
-        setSize(400, 100);
-        setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
+        setSize(440, 110);
+        setLayout(new BorderLayout());
         //Swing Worker can't update GUI components in modal jdialog
         //https://stackoverflow.com/questions/54496606/swing-worker-cant-update-gui-components-in-modal-jdialog
         setModalityType(Dialog.ModalityType.APPLICATION_MODAL);
         setLocationRelativeTo(null);
 
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-
-        JPanel contentPanel = new JPanel();
-        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.X_AXIS));
-        add(contentPanel);
-
-        contentPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
+        JPanel contentPanel = new JPanel(new BorderLayout(UiKit.GAP_MD, 0));
+        contentPanel.setBorder(new javax.swing.border.EmptyBorder(UiKit.PAD, UiKit.PAD, UiKit.PAD, UiKit.PAD));
+        contentPanel.add(progressBar, BorderLayout.CENTER);
+        contentPanel.add(progressLabel, BorderLayout.EAST);
+        add(contentPanel, BorderLayout.CENTER);
 
         progressBar.setMaximum(100);
         progressBar.setValue(0);
-        progressBar.setPreferredSize(new Dimension(300, 20));
-        contentPanel.add(progressBar);
-
-        contentPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-
-        contentPanel.add(progressLabel);
-
-        contentPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-
-        add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
     }
 
     public void setValue(int value) {

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/ui/UiKit.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/ui/UiKit.java
@@ -1,0 +1,252 @@
+package edu.jiangxin.apktoolbox.swing.extend.ui;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+/**
+ * Shared visual language for all tool panels.
+ * Spacing, form layout, buttons and section cards stay consistent app-wide.
+ */
+public final class UiKit {
+
+    public static final int GAP_XS = 4;
+    public static final int GAP_SM = 8;
+    public static final int GAP_MD = 12;
+    public static final int GAP_LG = 16;
+    public static final int PAD = 16;
+
+    public static final int LABEL_WIDTH = 140;
+    public static final int FIELD_HEIGHT = 28;
+    public static final int BUTTON_HEIGHT = 28;
+    public static final int BUTTON_WIDTH = 110;
+    public static final int BUTTON_HEIGHT_PRIMARY = 30;
+    public static final int BUTTON_WIDTH_PRIMARY = 120;
+    public static final int CONTENT_MAX_WIDTH = 920;
+
+    /** Android-inspired accent used only for primary actions / focus accents. */
+    public static final Color ACCENT = new Color(0x3D, 0xDC, 0x84);
+    public static final Color ACCENT_DARK = new Color(0x2E, 0xB8, 0x6B);
+    public static final Color DANGER = new Color(0xFF, 0x6B, 0x6B);
+    public static final Color MUTED = new Color(0x9E, 0xA3, 0xB0);
+
+    private UiKit() {
+    }
+
+    /** Apply global UI defaults after FlatLaf has been installed. */
+    public static void applyGlobalDefaults() {
+        UIManager.put("Component.focusWidth", 1);
+        UIManager.put("Component.innerFocusWidth", 0);
+        UIManager.put("Button.arc", 6);
+        UIManager.put("Component.arc", 6);
+        UIManager.put("TextComponent.arc", 4);
+        UIManager.put("TabbedPane.tabArc", 4);
+        UIManager.put("TabbedPane.tabHeight", 30);
+        UIManager.put("ScrollBar.width", 10);
+        UIManager.put("ToolPanel.borderConsumesSpace", false);
+    }
+
+    /** Section container with standard padding and optional titled border. */
+    public static JPanel card(String title) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BorderLayout());
+        panel.setBorder(sectionBorder(title));
+        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return panel;
+    }
+
+    public static Border sectionBorder(String title) {
+        if (title == null || title.isEmpty()) {
+            return new EmptyBorder(GAP_SM, GAP_SM, GAP_SM, GAP_SM);
+        }
+        Color lineColor = UIManager.getColor("Component.borderColor") != null
+                ? UIManager.getColor("Component.borderColor")
+                : new Color(0x4E, 0x52, 0x54);
+        return BorderFactory.createCompoundBorder(
+                BorderFactory.createTitledBorder(BorderFactory.createLineBorder(lineColor, 1), title),
+                new EmptyBorder(GAP_SM, GAP_XS, GAP_XS, GAP_XS));
+    }
+
+    /** Vertical stack with standard gaps. */
+    public static JPanel stack(JComponent... children) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        boolean first = true;
+        for (JComponent child : children) {
+            if (child == null) {
+                continue;
+            }
+            child.setAlignmentX(Component.LEFT_ALIGNMENT);
+            if (!first) {
+                panel.add(Box.createVerticalStrut(GAP_MD));
+            }
+            panel.add(child);
+            first = false;
+        }
+        return panel;
+    }
+
+    /**
+     * Form row: fixed-width right-aligned label + flexible fields.
+     * Accepts text fields, combos, checkboxes, buttons, etc.
+     */
+    public static JPanel formRow(String labelText, JComponent... fields) {
+        JPanel row = new JPanel(new GridBagLayout());
+        row.setAlignmentX(Component.LEFT_ALIGNMENT);
+        row.setOpaque(false);
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.gridy = 0;
+        gc.insets = new Insets(GAP_XS, GAP_XS, GAP_XS, GAP_XS);
+        gc.anchor = GridBagConstraints.WEST;
+
+        JLabel label = new JLabel(labelText);
+        label.setPreferredSize(new Dimension(LABEL_WIDTH, FIELD_HEIGHT));
+        label.setMaximumSize(new Dimension(LABEL_WIDTH, FIELD_HEIGHT));
+        gc.gridx = 0;
+        gc.weightx = 0;
+        gc.fill = GridBagConstraints.NONE;
+        row.add(label, gc);
+
+        gc.gridx = 1;
+        gc.weightx = 1.0;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        if (fields.length == 0) {
+            row.add(Box.createHorizontalGlue(), gc);
+        } else {
+            for (int i = 0; i < fields.length; i++) {
+                gc.gridx = 1 + i;
+                gc.weightx = i == fields.length - 1 ? 1.0 : 0.0;
+                gc.fill = i == fields.length - 1 ? GridBagConstraints.HORIZONTAL : GridBagConstraints.NONE;
+                JComponent field = fields[i];
+                field.setAlignmentX(Component.LEFT_ALIGNMENT);
+                if (field instanceof JTextField || field instanceof JButton) {
+                    field.setPreferredSize(preferredFieldSize(field));
+                    field.setMaximumSize(preferredFieldSize(field));
+                }
+                row.add(field, gc);
+            }
+        }
+        return row;
+    }
+
+    private static Dimension preferredFieldSize(JComponent c) {
+        int h = c instanceof JButton ? BUTTON_HEIGHT : FIELD_HEIGHT;
+        int w = c instanceof JButton ? BUTTON_WIDTH : Math.max(c.getPreferredSize().width, 120);
+        if (c.getPreferredSize().width > 0) {
+            w = Math.max(w, c.getPreferredSize().width);
+        }
+        return new Dimension(w, h);
+    }
+
+    /** Checkbox row with standard height. */
+    public static JPanel checkRow(JComponent... fields) {
+        JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, GAP_MD, GAP_XS));
+        row.setAlignmentX(Component.LEFT_ALIGNMENT);
+        row.setOpaque(false);
+        for (JComponent field : fields) {
+            field.setAlignmentY(Component.CENTER_ALIGNMENT);
+            row.add(field);
+        }
+        return row;
+    }
+
+    /** Right-aligned action bar with primary last (or first if only one). */
+    public static JPanel actionRow(JComponent... buttons) {
+        JPanel row = new JPanel(new FlowLayout(FlowLayout.RIGHT, GAP_SM, 0));
+        row.setAlignmentX(Component.LEFT_ALIGNMENT);
+        row.setOpaque(false);
+        for (JComponent button : buttons) {
+            if (button instanceof JButton jButton) {
+                if (jButton.getClientProperty("ui.primary") != null
+                        && Boolean.TRUE.equals(jButton.getClientProperty("ui.primary"))) {
+                    stylePrimaryButton(jButton);
+                } else {
+                    styleSecondaryButton(jButton);
+                }
+            }
+            row.add(button);
+        }
+        return row;
+    }
+
+    public static JButton primaryButton(String text) {
+        JButton button = new JButton(text);
+        button.putClientProperty("ui.primary", Boolean.TRUE);
+        stylePrimaryButton(button);
+        return button;
+    }
+
+    public static JButton secondaryButton(String text) {
+        JButton button = new JButton(text);
+        styleSecondaryButton(button);
+        return button;
+    }
+
+    public static void stylePrimaryButton(JButton button) {
+        button.setPreferredSize(new Dimension(BUTTON_WIDTH_PRIMARY, BUTTON_HEIGHT_PRIMARY));
+        button.setMinimumSize(new Dimension(BUTTON_WIDTH_PRIMARY, BUTTON_HEIGHT_PRIMARY));
+        button.setMaximumSize(new Dimension(Integer.MAX_VALUE, BUTTON_HEIGHT_PRIMARY));
+        button.setMargin(new Insets(0, GAP_MD, 0, GAP_MD));
+        button.setBackground(ACCENT);
+        button.setForeground(Color.BLACK);
+        button.setFocusPainted(false);
+        button.setFont(button.getFont().deriveFont(Font.BOLD));
+    }
+
+    public static void styleSecondaryButton(JButton button) {
+        button.setPreferredSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
+        button.setMinimumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
+        button.setMaximumSize(new Dimension(Integer.MAX_VALUE, BUTTON_HEIGHT));
+        button.setFocusPainted(false);
+    }
+
+    /** Uniform text field sizing. */
+    public static JTextField field(JTextField field) {
+        field.setPreferredSize(new Dimension(Math.max(field.getPreferredSize().width, 220), FIELD_HEIGHT));
+        field.setMaximumSize(new Dimension(Integer.MAX_VALUE, FIELD_HEIGHT));
+        field.setMinimumSize(new Dimension(120, FIELD_HEIGHT));
+        return field;
+    }
+
+    public static JLabel mutedLabel(String text) {
+        JLabel label = new JLabel(text);
+        label.setForeground(MUTED);
+        return label;
+    }
+
+    public static JLabel dangerLabel(String text) {
+        JLabel label = new JLabel(text);
+        label.setForeground(DANGER);
+        label.setFont(label.getFont().deriveFont(Font.BOLD));
+        return label;
+    }
+
+    /** Content panel constrained to a reasonable max width for readability. */
+    public static JPanel contentPane() {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBorder(new EmptyBorder(PAD, PAD, PAD, PAD));
+        return panel;
+    }
+
+    public static Dimension contentPreferred(int width, int height) {
+        return new Dimension(Math.min(width, CONTENT_MAX_WIDTH), height);
+    }
+}

--- a/src/main/java/edu/jiangxin/apktoolbox/swing/extend/ui/UiKit.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/swing/extend/ui/UiKit.java
@@ -4,9 +4,12 @@ import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.Box;
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
@@ -17,6 +20,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.FontMetrics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -36,7 +40,7 @@ public final class UiKit {
     public static final int LABEL_WIDTH = 140;
     public static final int FIELD_HEIGHT = 28;
     public static final int BUTTON_HEIGHT = 28;
-    public static final int BUTTON_WIDTH = 110;
+    public static final int BUTTON_WIDTH = 120;
     public static final int BUTTON_HEIGHT_PRIMARY = 30;
     public static final int BUTTON_WIDTH_PRIMARY = 120;
     public static final int CONTENT_MAX_WIDTH = 920;
@@ -106,57 +110,59 @@ public final class UiKit {
 
     /**
      * Form row: fixed-width right-aligned label + flexible fields.
-     * Accepts text fields, combos, checkboxes, buttons, etc.
+     * Text fields/combos expand; trailing action buttons keep text-based fixed width.
      */
     public static JPanel formRow(String labelText, JComponent... fields) {
         JPanel row = new JPanel(new GridBagLayout());
         row.setAlignmentX(Component.LEFT_ALIGNMENT);
         row.setOpaque(false);
+
         GridBagConstraints gc = new GridBagConstraints();
         gc.gridy = 0;
         gc.insets = new Insets(GAP_XS, GAP_XS, GAP_XS, GAP_XS);
         gc.anchor = GridBagConstraints.WEST;
+        gc.fill = GridBagConstraints.NONE;
+        gc.weightx = 0;
 
         JLabel label = new JLabel(labelText);
         label.setPreferredSize(new Dimension(LABEL_WIDTH, FIELD_HEIGHT));
+        label.setMinimumSize(new Dimension(LABEL_WIDTH, FIELD_HEIGHT));
         label.setMaximumSize(new Dimension(LABEL_WIDTH, FIELD_HEIGHT));
-        gc.gridx = 0;
-        gc.weightx = 0;
-        gc.fill = GridBagConstraints.NONE;
         row.add(label, gc);
 
-        gc.gridx = 1;
-        gc.weightx = 1.0;
-        gc.fill = GridBagConstraints.HORIZONTAL;
-        if (fields.length == 0) {
-            row.add(Box.createHorizontalGlue(), gc);
-        } else {
-            for (int i = 0; i < fields.length; i++) {
-                gc.gridx = 1 + i;
-                gc.weightx = i == fields.length - 1 ? 1.0 : 0.0;
-                gc.fill = i == fields.length - 1 ? GridBagConstraints.HORIZONTAL : GridBagConstraints.NONE;
-                JComponent field = fields[i];
-                field.setAlignmentX(Component.LEFT_ALIGNMENT);
-                if (field instanceof JTextField || field instanceof JButton) {
-                    field.setPreferredSize(preferredFieldSize(field));
-                    field.setMaximumSize(preferredFieldSize(field));
-                }
-                row.add(field, gc);
+        for (int i = 0; i < fields.length; i++) {
+            JComponent field = fields[i];
+            field.setAlignmentX(Component.LEFT_ALIGNMENT);
+            boolean isAction = field instanceof JButton;
+            boolean expand = !isAction && !(field instanceof JSpinner);
+            gc.gridx = 1 + i;
+            gc.weightx = expand ? 1.0 : 0.0;
+            gc.fill = expand ? GridBagConstraints.HORIZONTAL : GridBagConstraints.NONE;
+            if (isAction) {
+                styleSecondaryButton((JButton) field);
+            } else if (field instanceof JSpinner spinner) {
+                spinner.setPreferredSize(new Dimension(90, FIELD_HEIGHT));
+                spinner.setMaximumSize(new Dimension(90, FIELD_HEIGHT));
+                spinner.setMinimumSize(new Dimension(70, FIELD_HEIGHT));
+            } else if (expand) {
+                field.setPreferredSize(new Dimension(Math.max(field.getPreferredSize().width, 180), FIELD_HEIGHT));
+                field.setMinimumSize(new Dimension(120, FIELD_HEIGHT));
+                field.setMaximumSize(new Dimension(Integer.MAX_VALUE, FIELD_HEIGHT));
             }
+            row.add(field, gc);
         }
+
+        int rowHeight = FIELD_HEIGHT + GAP_XS * 2;
+        row.setPreferredSize(new Dimension(Math.max(row.getPreferredSize().width, 360), rowHeight));
+        row.setMaximumSize(new Dimension(Integer.MAX_VALUE, rowHeight));
         return row;
     }
 
-    private static Dimension preferredFieldSize(JComponent c) {
-        int h = c instanceof JButton ? BUTTON_HEIGHT : FIELD_HEIGHT;
-        int w = c instanceof JButton ? BUTTON_WIDTH : Math.max(c.getPreferredSize().width, 120);
-        if (c.getPreferredSize().width > 0) {
-            w = Math.max(w, c.getPreferredSize().width);
-        }
-        return new Dimension(w, h);
+    private static boolean isExpandable(JComponent c) {
+        return !(c instanceof JButton);
     }
 
-    /** Checkbox row with standard height. */
+    /** Checkbox / radio row with fixed height so BoxLayout does not stretch it. */
     public static JPanel checkRow(JComponent... fields) {
         JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, GAP_MD, GAP_XS));
         row.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -165,6 +171,9 @@ public final class UiKit {
             field.setAlignmentY(Component.CENTER_ALIGNMENT);
             row.add(field);
         }
+        int rowHeight = FIELD_HEIGHT + GAP_XS * 2;
+        row.setPreferredSize(new Dimension(Math.max(row.getPreferredSize().width, 240), rowHeight));
+        row.setMaximumSize(new Dimension(Integer.MAX_VALUE, rowHeight));
         return row;
     }
 
@@ -173,6 +182,8 @@ public final class UiKit {
         JPanel row = new JPanel(new FlowLayout(FlowLayout.RIGHT, GAP_SM, 0));
         row.setAlignmentX(Component.LEFT_ALIGNMENT);
         row.setOpaque(false);
+        row.setPreferredSize(new Dimension(Math.max(row.getPreferredSize().width, 200), BUTTON_HEIGHT_PRIMARY + GAP_XS));
+        row.setMaximumSize(new Dimension(Integer.MAX_VALUE, BUTTON_HEIGHT_PRIMARY + GAP_XS));
         for (JComponent button : buttons) {
             if (button instanceof JButton jButton) {
                 if (jButton.getClientProperty("ui.primary") != null
@@ -201,9 +212,11 @@ public final class UiKit {
     }
 
     public static void stylePrimaryButton(JButton button) {
-        button.setPreferredSize(new Dimension(BUTTON_WIDTH_PRIMARY, BUTTON_HEIGHT_PRIMARY));
-        button.setMinimumSize(new Dimension(BUTTON_WIDTH_PRIMARY, BUTTON_HEIGHT_PRIMARY));
-        button.setMaximumSize(new Dimension(Integer.MAX_VALUE, BUTTON_HEIGHT_PRIMARY));
+        int w = Math.max(BUTTON_WIDTH_PRIMARY, textWidth(button, GAP_LG));
+        button.setPreferredSize(new Dimension(w, BUTTON_HEIGHT_PRIMARY));
+        button.setMinimumSize(new Dimension(w, BUTTON_HEIGHT_PRIMARY));
+        // Keep width fixed so BoxLayout parents cannot stretch the accent button.
+        button.setMaximumSize(new Dimension(w, BUTTON_HEIGHT_PRIMARY));
         button.setMargin(new Insets(0, GAP_MD, 0, GAP_MD));
         button.setBackground(ACCENT);
         button.setForeground(Color.BLACK);
@@ -212,10 +225,17 @@ public final class UiKit {
     }
 
     public static void styleSecondaryButton(JButton button) {
-        button.setPreferredSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
-        button.setMinimumSize(new Dimension(BUTTON_WIDTH, BUTTON_HEIGHT));
-        button.setMaximumSize(new Dimension(Integer.MAX_VALUE, BUTTON_HEIGHT));
+        int w = Math.max(BUTTON_WIDTH, textWidth(button, GAP_MD));
+        button.setPreferredSize(new Dimension(w, BUTTON_HEIGHT));
+        button.setMinimumSize(new Dimension(w, BUTTON_HEIGHT));
+        button.setMaximumSize(new Dimension(w, BUTTON_HEIGHT));
         button.setFocusPainted(false);
+    }
+
+    private static int textWidth(JButton button, int pad) {
+        FontMetrics fm = button.getFontMetrics(button.getFont());
+        int text = fm.stringWidth(button.getText() == null ? "" : button.getText());
+        return text + pad * 2 + 8;
     }
 
     /** Uniform text field sizing. */

--- a/src/main/java/edu/jiangxin/apktoolbox/tools/PanelScreenshotMain.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/tools/PanelScreenshotMain.java
@@ -1,0 +1,186 @@
+package edu.jiangxin.apktoolbox.tools;
+
+import edu.jiangxin.apktoolbox.android.dumpsys.DumpsysPanel;
+import edu.jiangxin.apktoolbox.android.i18n.I18nAddPanel;
+import edu.jiangxin.apktoolbox.android.i18n.I18nFindLongestPanel;
+import edu.jiangxin.apktoolbox.android.i18n.I18nRemovePanel;
+import edu.jiangxin.apktoolbox.android.screenshot.ScreenShotPanel;
+import edu.jiangxin.apktoolbox.convert.color.ColorPickerPanel;
+import edu.jiangxin.apktoolbox.file.EncodeConvertPanel;
+import edu.jiangxin.apktoolbox.file.OsConvertPanel;
+import edu.jiangxin.apktoolbox.file.batchrename.BatchRenamePanel;
+import edu.jiangxin.apktoolbox.file.checksum.panel.FileChecksumPanel;
+import edu.jiangxin.apktoolbox.file.checksum.panel.StringHashPanel;
+import edu.jiangxin.apktoolbox.file.duplicate.DuplicateSearchPanel;
+import edu.jiangxin.apktoolbox.file.password.recovery.RecoveryPanel;
+import edu.jiangxin.apktoolbox.file.zhconvert.ZhConvertPanel;
+import edu.jiangxin.apktoolbox.help.AboutPanel;
+import edu.jiangxin.apktoolbox.help.settings.DependencyPathPanel;
+import edu.jiangxin.apktoolbox.help.settings.LocalePanel;
+import edu.jiangxin.apktoolbox.help.settings.LookAndFeelPanel;
+import edu.jiangxin.apktoolbox.pdf.finder.PdfFinderPanel;
+import edu.jiangxin.apktoolbox.pdf.passwordremover.PdfPasswordRemoverPanel;
+import edu.jiangxin.apktoolbox.pdf.pic2pdf.Pic2PdfPanel;
+import edu.jiangxin.apktoolbox.pdf.stat.PdfStatPanel;
+import edu.jiangxin.apktoolbox.reverse.AxmlPrinterPanel;
+import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
+import edu.jiangxin.apktoolbox.swing.extend.EasyChildTabbedPanel;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
+import edu.jiangxin.apktoolbox.utils.Utils;
+import edu.jiangxin.apktoolbox.word.stat.WordStatPanel;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Offline panel renderer for visual QA screenshots. */
+public final class PanelScreenshotMain {
+
+    private PanelScreenshotMain() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (!Utils.checkAndInitEnvironment()) {
+            System.err.println("Environment init failed");
+            System.exit(1);
+        }
+        UIManager.setLookAndFeel("com.formdev.flatlaf.FlatDarculaLaf");
+        UiKit.applyGlobalDefaults();
+
+        File outDir = new File(args.length > 0 ? args[0] : "ui-shots");
+        if (!outDir.exists() && !outDir.mkdirs()) {
+            throw new IllegalStateException("Cannot create " + outDir);
+        }
+
+        Map<String, Supplier<EasyPanel>> panels = new LinkedHashMap<>();
+        panels.put("about", AboutPanel::new);
+        panels.put("settings-lookandfeel", LookAndFeelPanel::new);
+        panels.put("settings-locale", LocalePanel::new);
+        panels.put("settings-dependency", DependencyPathPanel::new);
+        panels.put("encode-convert", EncodeConvertPanel::new);
+        panels.put("os-convert", OsConvertPanel::new);
+        panels.put("zh-convert", ZhConvertPanel::new);
+        panels.put("duplicate", DuplicateSearchPanel::new);
+        panels.put("batch-rename", BatchRenamePanel::new);
+        panels.put("checksum-file", FileChecksumPanel::new);
+        panels.put("checksum-string", StringHashPanel::new);
+        panels.put("recovery", RecoveryPanel::new);
+        panels.put("pdf-stat", PdfStatPanel::new);
+        panels.put("pdf-finder", PdfFinderPanel::new);
+        panels.put("pdf-password-remover", PdfPasswordRemoverPanel::new);
+        panels.put("pic2pdf", Pic2PdfPanel::new);
+        panels.put("word-stat", WordStatPanel::new);
+        panels.put("i18n-add", I18nAddPanel::new);
+        panels.put("i18n-remove", I18nRemovePanel::new);
+        panels.put("i18n-find-longest", I18nFindLongestPanel::new);
+        panels.put("screenshot", ScreenShotPanel::new);
+        panels.put("dumpsys", DumpsysPanel::new);
+        panels.put("apksigner-placeholder", null);
+        panels.put("axmlprinter", AxmlPrinterPanel::new);
+        panels.put("color-picker", ColorPickerPanel::new);
+
+        // ApkSigner needs plugin base; still can init UI
+        panels.put("apksigner", edu.jiangxin.apktoolbox.reverse.ApkSignerPanel::new);
+        panels.remove("apksigner-placeholder");
+
+        List<String> failures = new ArrayList<>();
+        for (Map.Entry<String, Supplier<EasyPanel>> entry : panels.entrySet()) {
+            String name = entry.getKey();
+            try {
+                EasyPanel panel = entry.getValue().get();
+                if (panel instanceof EasyChildTabbedPanel child) {
+                    child.onTabSelected();
+                } else {
+                    panel.init();
+                }
+                File file = renderPanel(panel, new File(outDir, name + ".png"));
+                System.out.println("OK  " + name + " -> " + file.getAbsolutePath());
+            } catch (Throwable t) {
+                failures.add(name + ": " + t);
+                System.err.println("FAIL " + name + " -> " + t);
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            System.err.println("Failures: " + failures);
+            System.exit(2);
+        }
+        System.exit(0);
+    }
+
+    private static File renderPanel(JPanel panel, File outFile) throws Exception {
+        panel.setSize(panel.getPreferredSize());
+        Dimension pref = panel.getPreferredSize();
+        int w = Math.max(640, Math.min(1100, Math.max(pref.width, 640)));
+        int h = Math.max(360, Math.min(900, Math.max(pref.height, 360)));
+
+        // Prefer a live frame pack when possible for more realistic layout.
+        JFrame frame = new JFrame();
+        frame.setUndecorated(true);
+        frame.setLayout(new BorderLayout());
+        frame.add(panel, BorderLayout.CENTER);
+        frame.pack();
+        int fw = Math.max(720, frame.getWidth());
+        int fh = Math.max(400, frame.getHeight());
+        frame.setSize(fw, fh);
+        frame.setVisible(true);
+        // Let layout/paint settle.
+        for (int i = 0; i < 12; i++) {
+            frame.validate();
+            frame.paintAll(frame.getGraphics());
+            Thread.sleep(20);
+        }
+        BufferedImage image = new BufferedImage(fw, fh, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = image.createGraphics();
+        panel.paintAll(g);
+        g.dispose();
+        frame.dispose();
+
+        // If panel painted empty/black, fall back to whole frame snapshot.
+        if (isNearlyUniform(image)) {
+            frame = new JFrame();
+            frame.setUndecorated(true);
+            frame.setLayout(new BorderLayout());
+            frame.add(panel, BorderLayout.CENTER);
+            frame.pack();
+            frame.setSize(fw, fh);
+            frame.setVisible(true);
+            frame.validate();
+            SwingUtilities.invokeAndWait(() -> {
+            });
+            Thread.sleep(50);
+            image = new Robot().createScreenCapture(new Rectangle(0, 0, fw, fh));
+            // Position at origin for robot capture reliability
+            frame.setLocation(0, 0);
+            frame.toFront();
+            Thread.sleep(80);
+            image = new Robot().createScreenCapture(new Rectangle(0, 0, Math.min(fw, 1200), Math.min(fh, 900)));
+            frame.dispose();
+        }
+
+        ImageIO.write(image, "png", outFile);
+        return outFile;
+    }
+
+    private static boolean isNearlyUniform(BufferedImage image) {
+        int sample = image.getRGB(10, 10);
+        int same = 0;
+        int total = 0;
+        for (int y = 0; y < image.getHeight(); y += 40) {
+            for (int x = 0; x < image.getWidth(); x += 40) {
+                total++;
+                if (image.getRGB(x, y) == sample) {
+                    same++;
+                }
+            }
+        }
+        return total > 0 && same * 1.0 / total > 0.97;
+    }
+}

--- a/src/main/java/edu/jiangxin/apktoolbox/word/stat/WordStatPanel.java
+++ b/src/main/java/edu/jiangxin/apktoolbox/word/stat/WordStatPanel.java
@@ -2,14 +2,16 @@ package edu.jiangxin.apktoolbox.word.stat;
 
 import edu.jiangxin.apktoolbox.swing.extend.EasyPanel;
 import edu.jiangxin.apktoolbox.swing.extend.FileListPanel;
-import edu.jiangxin.apktoolbox.utils.Constants;
+import edu.jiangxin.apktoolbox.swing.extend.ui.UiKit;
 import edu.jiangxin.apktoolbox.utils.DateUtils;
 import edu.jiangxin.apktoolbox.utils.ExcelExporter;
 import edu.jiangxin.apktoolbox.utils.FileUtils;
 import edu.jiangxin.apktoolbox.word.WordUtils;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -65,7 +67,7 @@ public class WordStatPanel extends EasyPanel {
         add(tabbedPane);
 
         createMainPanel();
-        tabbedPane.addTab("Option", null, mainPanel, "Show Stat Options");
+        tabbedPane.addTab("Options", null, mainPanel, "Show Stat Options");
 
         createResultPanel();
         tabbedPane.addTab("Result", null, resultPanel, "Show Stat Result");
@@ -74,53 +76,51 @@ public class WordStatPanel extends EasyPanel {
     private void createMainPanel() {
         mainPanel = new JPanel();
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        mainPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         fileListPanel = new FileListPanel();
         fileListPanel.initialize();
 
-        JPanel searchOptionPanel = new JPanel();
-        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.X_AXIS));
-        searchOptionPanel.setBorder(BorderFactory.createTitledBorder("Stat Options"));
-
         isRecursiveSearched = new JCheckBox("Recursive");
         isRecursiveSearched.setSelected(true);
-        searchOptionPanel.add(isRecursiveSearched);
-        searchOptionPanel.add(Box.createHorizontalGlue());
 
-        JPanel operationPanel = new JPanel();
-        operationPanel.setLayout(new BoxLayout(operationPanel, BoxLayout.X_AXIS));
-        operationPanel.setBorder(BorderFactory.createTitledBorder("Operations"));
+        JPanel searchOptionPanel = new JPanel();
+        searchOptionPanel.setLayout(new BoxLayout(searchOptionPanel, BoxLayout.Y_AXIS));
+        searchOptionPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        searchOptionPanel.setBorder(UiKit.sectionBorder("Stat Options"));
+        searchOptionPanel.add(UiKit.checkRow(isRecursiveSearched));
 
-        statButton = new JButton("Stat");
-        cancelButton = new JButton("Cancel");
+        statButton = UiKit.primaryButton("Stat");
+        cancelButton = UiKit.secondaryButton("Cancel");
         cancelButton.setEnabled(false);
         statButton.addActionListener(new OperationButtonActionListener());
         cancelButton.addActionListener(new OperationButtonActionListener());
-        operationPanel.add(statButton);
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(Box.createHorizontalStrut(Constants.DEFAULT_X_BORDER));
-        operationPanel.add(cancelButton);
-        operationPanel.add(Box.createHorizontalGlue());
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
         progressBar.setString("Ready");
+        progressBar.setPreferredSize(new Dimension(0, 22));
+        progressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 22));
 
         mainPanel.add(fileListPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
         mainPanel.add(searchOptionPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        mainPanel.add(operationPanel);
-        mainPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_MD));
+        mainPanel.add(UiKit.actionRow(cancelButton, statButton));
+        mainPanel.add(Box.createVerticalStrut(UiKit.GAP_SM));
         mainPanel.add(progressBar);
     }
 
     private void createResultPanel() {
         resultPanel = new JPanel();
-        resultPanel.setLayout(new BoxLayout(resultPanel, BoxLayout.Y_AXIS));
+        resultPanel.setLayout(new BorderLayout());
+        resultPanel.setBorder(new EmptyBorder(UiKit.GAP_XS, 0, 0, 0));
 
         resultTableModel = new WordFilesTableModel(new Vector<>(), WordFilesConstants.COLUMN_NAMES);
         resultTable = new JTable(resultTableModel);
+        resultTable.setRowHeight(28);
+        resultTable.setShowGrid(false);
+        resultTable.setIntercellSpacing(new Dimension(0, 0));
         resultTable.setDefaultRenderer(Vector.class, new WordFilesTableCellRenderer());
         for (int i = 0; i < resultTable.getColumnCount(); i++) {
             resultTable.getColumn(resultTable.getColumnName(i)).setCellRenderer(new WordFilesTableCellRenderer());
@@ -131,7 +131,7 @@ public class WordStatPanel extends EasyPanel {
             public void mouseReleased(MouseEvent e) {
                 if (e.isPopupTrigger() && e.getComponent() instanceof JTable) {
                     JPopupMenu popupmenu = new JPopupMenu();
-                    JMenuItem exportMenuItem = new JMenuItem("导出到 Excel");
+                    JMenuItem exportMenuItem = new JMenuItem("Export to Excel");
                     exportMenuItem.addActionListener(ev ->
                         ExcelExporter.export(resultTableModel, "word_stat_export.xlsx", WordStatPanel.this));
                     popupmenu.add(exportMenuItem);
@@ -147,9 +147,8 @@ public class WordStatPanel extends EasyPanel {
         statInfoPanel.add(statInfoLabel);
         statInfoPanel.add(Box.createHorizontalGlue());
 
-        resultPanel.add(scrollPane);
-        resultPanel.add(Box.createVerticalStrut(Constants.DEFAULT_Y_BORDER));
-        resultPanel.add(statInfoPanel);
+        resultPanel.add(scrollPane, BorderLayout.CENTER);
+        resultPanel.add(statInfoPanel, BorderLayout.SOUTH);
     }
 
     private void processFile(File file) {


### PR DESCRIPTION
## Summary

Unify visual style across ApkToolBoxGUI tool screens under FlatLaf Darcula, then re-verify each panel with local screenshots and fix layout defects found in that pass.

### Design system
- New `UiKit` (`swing/extend/ui/UiKit.java`): spacing, section cards, form rows, primary/secondary buttons, FlatLaf defaults
- Shell polish: `MainFrame`, `EasyPanel`, `EasyFrame`, shared `FileListPanel` / `FilePanel` / `ProgressBarDialog`

### Commits (23) — screens covered

| Commit | Screen / area |
|---|---|
| `feat(ui): introduce UiKit…` | Design system + shell + FileList/FilePanel |
| `refactor(ui): unify EncodeConvertPanel` | File → Convert Encoding |
| `refactor(ui): unify OsConvertPanel` | File → Convert OS Pattern |
| `refactor(ui): unify ZhConvertPanel` | File → Simplified/Traditional Chinese |
| `refactor(ui): unify DuplicateSearchPanel` | File → Find duplicate files |
| `refactor(ui): polish BatchRenamePanel` | File → Batch Rename (warning + Start) |
| `refactor(ui): unify Checksum tab panels` | File → Check Summary (File + String tabs) |
| `refactor(ui): unify RecoveryPanel` + polish | File → Recover File Password |
| `refactor(ui): unify PdfStatPanel` | PDF → Statistics |
| `refactor(ui): unify PdfFinderPanel` | PDF → Find Special PDF files |
| `refactor(ui): unify PdfPasswordRemoverPanel` | PDF → Remove Password |
| `refactor(ui): unify Pic2PdfPanel` | PDF → Pictures to PDF |
| `refactor(ui): unify WordStatPanel` | Word → Statistics |
| `refactor(ui): unify Android I18n panels` | Android → I18n add/remove/find longest |
| `refactor(ui): unify ScreenShotPanel` | Android → Screenshot |
| `refactor(ui): unify DumpsysPanel` + fix grid | Android → Dumpsys |
| `refactor(ui): unify ApkSignerPanel` | Reverse → ApkSigner |
| `refactor(ui): unify AxmlPrinterPanel` | Reverse → AXMLPrinter |
| `refactor(ui): unify AboutPanel and LookAndFeel` | Help → About / Look and Feel |
| `refactor(ui): unify Locale, Dependency Path, ProgressBar` | Help → Settings tabs + download dialog |
| `fix(ui): correct form stretch…` | Visual QA fixes from screenshots |
| `chore: ignore local ui-shots` | gitignore only |
| `refactor(ui): polish Password Recovery` | Recovery final layout after QA |

### Not in this PR
- Monkey, Apktool, ColorPicker, Verify/Compare/ScanFolder checksum tabs, AlwaysOnTop / Add to Startup — left as follow-ups (heavy or low churn)

## Functional impact review

**Core conversion / recovery / hash / dumpsys / screenshot / i18n algorithms were not rewritten.** Diff is almost entirely Swing layout (`BoxLayout`/`GridBag`/`BorderLayout`), labels, buttons, borders.

### Intentional small behavior deltas (UI-level only)
1. **Dumpsys analysis tab**: fixed stray `VerticalStrut` added to the wrong parent (real bug).
2. **Dumpsys types**: type checkboxes rebuilt in a 4-column grid; `input` is now present in the list (original built `inputCheckBox` but never added it to the panel, so it was not selectable).
3. **Checksum result fields**: marked non-editable (still fully readable/copyable).
4. **Screenshot**: button label typo `Sceenshot` → `Screenshot`; “File Name” button now focuses the field.
5. **Copy/dialog strings**: some Chinese hard-coded dialogs in ZhConvert → English for consistency with default UI locale; file write logic unchanged.
6. **EasyPanel**: default empty border at construction; `MainFrame` still replaces with titled section border after `init()`.
7. **EasyFrame**: minimum window size 800×100 → 880×120.
8. **Button texts**: FileList side actions shortened (`Add Dir` / `Remove` / `Invert`); listeners unchanged.

### Explicitly unchanged
- Thread pools, executors, file IO, PDF/POI/iText/adb command construction
- `conf.setProperty` keys and paths
- Menu routing / panel lifecycle (`init` / `afterPainted` / UiStateKeeper)
- Recovery `onStart` / `onStop` state machine and enable/disable

### Build
- `mvn -DskipTests compile` **SUCCESS** on branch tip
- Remote CI not monitored (per request)

## Test plan
- [x] Local compile clean
- [x] Screenshot pass over major panels (`PanelScreenshotMain`)
- [ ] Manual smoke: encode/os/zh convert, checksum file+string, recovery start/stop, dumpsys select-all + start, screenshot adb path
- [ ] Optional `mvn test`